### PR TITLE
bugfix for is.smiles

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -261,12 +261,14 @@ is.smiles <- function(x, verbose = TRUE) {
     stop('Cannot handle multiple input strings.')
   }
   out <- try(rcdk::parse.smiles(x), silent = TRUE)
-  if (inherits(out, 'try-error') | is.na(out)) {
+  if (inherits(out[[1]], "try-error") | is.null(out[[1]])) {
     return(FALSE)
   } else {
     return(TRUE)
   }
 }
+
+
 
 
 #' Extract a number from a string


### PR DESCRIPTION
Hello - I recently ran into an issue with this function using the current CRAN version of webchem, but I believe this issue still exists in the master branch here. Apologies if I am supposed to file a pull request against a different branch than master. 

is.smiles previously returned TRUE for any string regardless of validity. I suspect this was due to changes in rcdk::parse.smiles. 

This change should correctly return TRUE for valid SMILES, and FALSE for un-parseable SMILES.