### PR TITLE
pc_synonyms multiple compounds per request

### DIFF
--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -242,7 +242,7 @@ pc_synonyms <- function(query, from = 'name', interactive = 0, verbose = TRUE, C
     )
     
     if (inherits(cont, "try-error")) {
-      if(length(query) > 1){
+      if (length(query) > 1) {
         warning('Problem with web service encountered... Trying chemicals individually.')
         cont <- lapply(query, foo, from=from, verbose=verbose)
       } else {
@@ -250,14 +250,14 @@ pc_synonyms <- function(query, from = 'name', interactive = 0, verbose = TRUE, C
         return(NA)
       }
     } else if (names(cont) == 'Fault') {
-      if(length(query) > 1){
+      if (length(query) > 1) {
         warning(cont$Fault$Details, '. Trying chemicals individually.')
         cont <- lapply(query, foo, from=from, verbose=verbose)
       } else {
         warning(cont$Fault$Details, '. Returning NA.')
         return(NA)
       }
-    } else {
+    } else if (length(query) > 1) {
       cont <- cont$InformationList$Information
     }
     
@@ -278,19 +278,18 @@ pc_synonyms <- function(query, from = 'name', interactive = 0, verbose = TRUE, C
   
   if(from %in% c('name','smiles','inchi','inchikey','sdf')){
     #Only single strings per request are suppoprted for these identifiers.
-    CHUNKSIZE = 1
-  }
-  
-  if (length(query) > CHUNKSIZE) {
+    out <- lapply(query, foo, from=from, verbose=verbose)
+    out <- do.call(c, out)
+  } else if (length(query) > CHUNKSIZE) {
     query_chunks <- split(query, ceiling(seq_along(query)/CHUNKSIZE))
     out <- lapply(query_chunks, foo, from=from, verbose=verbose)
     out <- do.call(c, out)
   } else {
     out <- foo(query, from = from, verbose = verbose)
   }
+  
   out <- setNames(out, query)
   return(out)
 }
-
 
 

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -259,6 +259,11 @@ pc_synonyms <- function(query, from = 'name', interactive = 0, verbose = TRUE, C
       }
     } else if (length(query) > 1) {
       cont <- cont$InformationList$Information
+      if (length(cont) > length(query)) {
+        #One or more chemicals map to multiple CIDs.
+        #The current results cannot distinguish which, so redo each chemical individually.
+        cont <- lapply(query, foo, from=from, verbose=verbose)
+      }
     }
     
     out <- lapply(lapply(cont, unlist), unname)

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -234,18 +234,20 @@ pc_synonyms <- function(query, from = 'name', interactive = 0, verbose = TRUE, C
       message(qurl)
     Sys.sleep(0.2)
     
+    query_commasep = paste0(query,collapse=',')
+    
     cont <- try(content(POST(qurl,
-                             body = paste0(from, '=', paste0(query,collapse=','))
+                             body = paste0(from, '=', query_commasep)
     )), silent = TRUE
     )
     
     if (inherits(cont, "try-error")) {
       warning('Problem with web service encountered... Returning NA.')
-      return(NA)
+      return(rep(NA, length = length(query)))
     }
     if (names(cont) == 'Fault') {
       warning(cont$Fault$Details, '. Returning NA.')
-      return(NA)
+      return(rep(NA, length = length(query)))
     }
     
     out <- lapply(lapply(cont$InformationList$Information, unlist),unname)


### PR DESCRIPTION
In this new version, `pc_synonyms` will submit `CHUNKSIZE` compounds per request, instead of one per request. This should be faster.

This is my first pull request so I apologize for any mistakes; hopefully this is helpful!