### PR TITLE
is.cas() alpha-character error

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -184,6 +184,12 @@ is.cas <-  function(x, verbose = TRUE) {
     stop('Cannot handle multiple input strings.')
   }
 
+  # cas must not have any alpha characters
+  if(grepl(pattern = "[[:alpha:]]", x = x)){
+    if(verbose){message("String contains alpha characters")}
+    return(FALSE)
+  }
+
   # cas must have two hyphens
   nsep <- str_count(x, '-')
   if (nsep != 2) {


### PR DESCRIPTION
Add functionality to the is.cas() function to catch hyphen-separated strings that contain alpha characters, returns FALSE and prints warning message.

```r
x <- "Del-VI-A" #synonym retrieved from cir_query(identifier = '11103-57-4', 'names')
is.cas(x = x, verbose = T)
```
