### PR TITLE
Fixes #168

### DIFF
--- a/R/pan.R
+++ b/R/pan.R
@@ -113,7 +113,7 @@ pan_query <- function(query, match = c('best', 'all', 'first'), verbose = TRUE, 
     out <- as.list(ttt)
     # clean
     out$`Detailed Info` <- NULL
-    names(out) <- gsub('\\n', '', names(out))
+    names(out) <- gsub('\\n', ' ', names(out))
     out <- rapply(out, f = function(x){
       ifelse(x %in% c('null', '-', ''), NA, x)
     }, how = "replace" )


### PR DESCRIPTION
String substitution for pan_query output replaced with ``\n`` with ``""`` (e.g., ``Chemical Nameand matching synonym``) Later code indexed output with name containing a space (eg., ``Chemical Name and matching synonym``). 

Replaced empty character with space in 
```r
names(out) <- gsub('\\n', ' ', names(out))
```

```r
webchem::pan_query("2,4-D")
```
