### PR TITLE
Fix for #180

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -354,6 +354,8 @@ as.cas <- function(x){
   format.cas <- function(x){
     if(is.na(x)) {
       return(NA)
+    } else if (suppressMessages(is.cas(x))) {
+      return(x)
     } else {
       parsed <- gsub("([0-9]+)([0-9]{2})([0-9]{1})", '\\1-\\2-\\3', x)
       pass <- is.cas(parsed)
@@ -361,9 +363,7 @@ as.cas <- function(x){
       return(out)
     }
   }
-  if(any(!sapply(x, grepl, pattern= "^\\d+$"))){
-    warning("Some elements of x cannot be converted to CAS numbers")
-  }
+
   sapply(x, format.cas, USE.NAMES = FALSE)
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -13,6 +13,12 @@ test_that("is.cas() returns correct results", {
   expect_error(is.cas(c('64-17-5', '64-17-5')))
 })
 
+test_that("as.cas() handles properly formatted CAS",{
+  skip_on_cran()
+
+  expect_identical(as.cas("64-17-5"), "64-17-5")
+  expect_silent(as.cas("64-17-5"))
+})
 
 test_that("is.inchikey() returns correct results", {
   skip_on_cran()


### PR DESCRIPTION
This fixes a problem where `as.cas()` would fail on correctly formatted CAS numbers.  Also slightly changes the behavior to remove a blanket warning ("some elements couldn't be converted to CAS numbers") and instead just show the warnings passed by `is.cas()`.


PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed