### PR TITLE
Fix aw_query to enforce uniform output structure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,4 +36,4 @@ Imports:
 Suggests:
     testthat,
     rcdk
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,19 @@
-webchem 0.5
+webchem 0.6.0
+======================
+
+NEW FEATURES
+
+MINOR IMPROVEMENTS
+
+BUG FIXES
+
+* aw_query() returned a list for successful queries, NA for unsuccessful queries [PR #222, fixed by stitam]
+
+DEPRECATED FUNCTIONS
+
+DEFUNCT FUNCTIONS
+
+webchem 0.5.0
 ======================
 
 NEW FEATURES
@@ -35,7 +50,7 @@ DEFUNCT FUNCTIONS
 * pp_query() has been removed. Physprop API is no longer active.
 * cs_prop() has been removed.
 
-webchem 0.4
+webchem 0.4.0
 ======================
 
 NEW FEATURES
@@ -58,7 +73,7 @@ DEPRECATED FUNCTIONS
 DEFUNCT FUNCTIONS
 
 
-webchem 0.3
+webchem 0.3.0
 ======================
 
 NEW FEATURES
@@ -81,7 +96,7 @@ DEPRECATED FUNCTIONS
 DEFUNCT FUNCTIONS
 
 
-webchem 0.2
+webchem 0.2.0
 ======================
 
 NEW FEATURES
@@ -157,7 +172,7 @@ The new ppdb_parse() parses only a html, but does not interact with the database
 
 
 
-webchem 0.0.5.0
+webchem 0.0.5
 ======================
 
 NEW FEATURES
@@ -209,7 +224,7 @@ DEFUNCT FUNCTIONS
 
 
 
-webchem 0.0.4.0
+webchem 0.0.4
 ======================
 
 NEW FEATURES

--- a/R/alanwood.R
+++ b/R/alanwood.R
@@ -1,19 +1,22 @@
 #' Query http://www.alanwood.net/pesticides
 #'
-#' Query Alan Woods Compendium of Pesticide Common Names \url{http://www.alanwood.net/pesticides}
+#' Query Alan Woods Compendium of Pesticide Common Names
+#' \url{http://www.alanwood.net/pesticides}
 #' @import xml2
 #' @importFrom stats rgamma
 #'
 #' @param  query character; search string
 #' @param type character; type of input ('cas' or 'commonname')
 #' @param verbose logical; print message during processing to console?
-#' @param idx data.frame; index to use. If NULL (default) the internal index \code{\link{aw_idx}} is used.
-#' To rebuild the index use \code{\link{build_aw_idx}}.
-#' @return A list of eight entries: common-name, status, preferredd IUPAC Name,
-#'          IUPAC Name, cas, formula, activity, subactivity, inchikey, inchi and source url.
-#'
+#' @param idx data.frame; index to use. If NULL (default) the internal index
+#' \code{\link{aw_idx}} is used. To rebuild the index use
+#' \code{\link{build_aw_idx}}.
+#' @return A list of eight entries: common-name, status, preferred IUPAC Name,
+#' IUPAC Name, cas, formula, activity, subactivity, inchikey, inchi and source
+#' url.
 #' @note for type = 'cas' only the first matched link is returned.
-#' Please respect Copyright, Terms and Conditions \url{http://www.alanwood.net/pesticides/legal.html}!
+#' Please respect Copyright, Terms and Conditions
+#' \url{http://www.alanwood.net/pesticides/legal.html}!
 #' @author Eduard Szoecs, \email{eduardszoecs@@gmail.com}
 #' @export
 #' @examples
@@ -27,92 +30,116 @@
 #' # use CAS-numbers
 #' aw_query("79622-59-6", type = 'cas')
 #' }
-aw_query <- function(query, type = c("commonname", "cas"), verbose = TRUE, idx = NULL){
-  # query <- 'Fluazinam'
+aw_query <- function(query, type = c("commonname", "cas"), verbose = TRUE,
+                     idx = NULL) {
   foo <- function(query, type = c("commonname", "cas"), verbose, idx = NULL) {
     type <- match.arg(type)
     if (is.null(idx)) {
       idx <- webchem::aw_idx
     }
   # search links in indexes
-    if (type == 'commonname' ) {
-      links <- idx$links[idx$source == 'cn']
-      names <- idx$linknames[idx$source == 'cn']
+    if (type == "commonname") {
+      links <- idx$links[idx$source == "cn"]
+      names <- idx$linknames[idx$source == "cn"]
       cname <-  query
     }
 
-    if (type == 'cas') {
-      names <- idx$names[idx$source == 'rn']
+    if (type == "cas") {
+      names <- idx$names[idx$source == "rn"]
       # select only first link
-      links <- idx$links[idx$source == 'rn']
-      linknames <- idx$linknames[idx$source == 'rn']
+      links <- idx$links[idx$source == "rn"]
+      linknames <- idx$linknames[idx$source == "rn"]
       cname <-  linknames[tolower(names) == tolower(query)]
     }
 
     takelink <- links[tolower(names) == tolower(query)]
     if (length(takelink) == 0) {
-      message('Not found! Returning NA.\n')
-      return(NA)
+      message("Not found! Returning NA.\n")
+      return(list(cname = NA,
+                  status = NA,
+                  pref_iupac_name = NA,
+                  iupac_name = NA,
+                  cas = NA,
+                  formula = NA,
+                  activity = NA,
+                  subactivity = NA,
+                  inchikey = NA,
+                  inch = NA,
+                  source_url = NA))
     }
     if (length(takelink) > 1) {
       takelink <- unique(takelink)
       if (length(takelink) > 1) {
-        message('More then one link found! Returning first.\n')
+        message("More then one link found! Returning first.\n")
         takelink <- takelink[1]
       }
     }
     if (verbose)
-      message('Querying ', takelink)
+      message("Querying ", takelink)
 
-    Sys.sleep( rgamma(1, shape = 15, scale = 1/10))
-    ttt <- read_html(paste0('http://www.alanwood.net/pesticides/', takelink))
+    Sys.sleep(rgamma(1, shape = 15, scale = 1/10))
+    ttt <- read_html(paste0("http://www.alanwood.net/pesticides/", takelink))
 
-    status <- xml_text(xml_find_all(ttt, "//tr/th[@id='r1']/following-sibling::td"))
-    pref_iupac_name <- xml_text(xml_find_all(ttt, "//tr/th[@id='r2']/following-sibling::td"))
-    iupac_name <- xml_text(xml_find_all(ttt, "//tr/th[@id='r3']/following-sibling::td"))
-    cas <- xml_text(xml_find_all(ttt, "//tr/th[@id='r5']/following-sibling::td"))
-    formula <- xml_text(xml_find_all(ttt, "//tr/th[@id='r6']/following-sibling::td"))
-    activity <- xml_text(xml_find_all(ttt, "//tr/th[@id='r7']/following-sibling::td"))
-    subactivity <- trimws(strsplit(gsub('^.*\\((.*)\\)', '\\1', activity), ';')[[1]])
-    activity <- gsub('^(.*) \\(.*\\)', '\\1', activity)
-    inchikey_r <- xml_text(xml_find_all(ttt, "//tr/th[@id='r11']/following-sibling::td"))
+    status <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r1']/following-sibling::td"))
+    pref_iupac_name <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r2']/following-sibling::td"))
+    iupac_name <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r3']/following-sibling::td"))
+    cas <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r5']/following-sibling::td"))
+    formula <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r6']/following-sibling::td"))
+    activity <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r7']/following-sibling::td"))
+    subactivity <- trimws(
+      strsplit(gsub("^.*\\((.*)\\)", "\\1", activity), ";")[[1]])
+    activity <- gsub("^(.*) \\(.*\\)", "\\1", activity)
+    inchikey_r <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r11']/following-sibling::td"))
     if (length(inchikey_r) == 0) {
       inchikey <- NA
     } else {
-      if (grepl('isomer', inchikey_r)) {
-        inchikey <- c(s_isomer = gsub('.*\\(S\\)-isomer:(.*)(minor component.*)', '\\1', inchikey_r),
-          r_isomer = gsub('.*\\(R\\)-isomer:(.*)', '\\1', inchikey_r))
+      if (grepl("isomer", inchikey_r)) {
+        inchikey <- c(
+          s_isomer = gsub(
+            ".*\\(S\\)-isomer:(.*)(minor component.*)", "\\1", inchikey_r),
+          r_isomer = gsub(".*\\(R\\)-isomer:(.*)", "\\1", inchikey_r))
       }
-      if (grepl('identifier', inchikey_r)) {
-        inchikey <- c(gsub('(.*)identifier.*', '\\1', inchikey_r), gsub('.*identifier.*:(.*)', '\\1', inchikey_r))
-        names(inchikey) <- c('inchikey',
-                             gsub('.*(identifier.*:).*', '\\1', inchikey_r)
+      if (grepl("identifier", inchikey_r)) {
+        inchikey <- c(gsub("(.*)identifier.*", "\\1", inchikey_r),
+                      gsub(".*identifier.*:(.*)", "\\1", inchikey_r))
+        names(inchikey) <- c("inchikey",
+                             gsub(".*(identifier.*:).*", "\\1", inchikey_r)
                              )
       }
-      if (!grepl('isomer', inchikey_r) & !grepl('identifier', inchikey_r))
+      if (!grepl("isomer", inchikey_r) & !grepl("identifier", inchikey_r))
         inchikey <- inchikey_r
     }
 
-    inchi <- xml_text(xml_find_all(ttt, "//tr/th[@id='r12']/following-sibling::td"))
+    inchi <- xml_text(
+      xml_find_all(ttt, "//tr/th[@id='r12']/following-sibling::td"))
     if (length(inchi) == 0) {
       inchi <- NA
     } else {
-      if (grepl('isomer', inchi)) {
-        inchi <- c(s_isomer = gsub('.*\\(S\\)-isomer:(.*)(minor component.*)', '\\1', inchi),
-                   r_isomer = gsub('.*\\(R\\)-isomer:(.*)', '\\1', inchi))
+      if (grepl("isomer", inchi)) {
+        inchi <- c(s_isomer = gsub(".*\\(S\\)-isomer:(.*)(minor component.*)",
+                                   "\\1", inchi),
+                   r_isomer = gsub(".*\\(R\\)-isomer:(.*)", "\\1", inchi))
       }
     }
     # add source url
-    source_url <- paste0('http://www.alanwood.net/pesticides/', takelink)
-    out <- list(cname = cname, status = status, pref_iupac_name = pref_iupac_name,
-                iupac_name = iupac_name, cas = cas, formula = formula,
-                activity = activity, subactivity = subactivity,
-                inchikey = inchikey, inch = inchi, source_url = source_url)
+    source_url <- paste0("http://www.alanwood.net/pesticides/", takelink)
+    out <- list(cname = cname, status = status,
+                pref_iupac_name = pref_iupac_name, iupac_name = iupac_name,
+                cas = cas, formula = formula, activity = activity,
+                subactivity = subactivity, inchikey = inchikey, inch = inchi,
+                source_url = source_url)
     return(out)
   }
   out <- lapply(query, foo, type = type, verbose = verbose, idx = idx)
   out <- setNames(out, query)
-  class(out) <- c('aw_query', 'list')
+  class(out) <- c("aw_query", "list")
   return(out)
 }
 
@@ -124,37 +151,38 @@ aw_query <- function(query, type = c("commonname", "cas"), verbose = TRUE, idx =
 #' @export
 #' @seealso \code{\link{aw_query}}, \code{\link{aw_idx}}
 #'@author Eduard Szoecs, \email{eduardszoecs@@gmail.com}
-build_aw_idx <- function(){
-  idx1 <- read_html('http://www.alanwood.net/pesticides/index_rn.html')
-  # idx2 <- read_html('http://www.alanwood.net/pesticides/index_rn1.html')
-  # idx3 <- read_html('http://www.alanwood.net/pesticides/index_rn2.html')
+build_aw_idx <- function() {
+  idx1 <- read_html("http://www.alanwood.net/pesticides/index_rn.html")
+  # idx2 <- read_html("http://www.alanwood.net/pesticides/index_rn1.html")
+  # idx3 <- read_html("http://www.alanwood.net/pesticides/index_rn2.html")
   prep_idx <- function(y) {
     names <- xml_text(xml_find_all(y, "//dl/dt"))
-    links <- xml_attr(xml_find_all(y, '//dt/following-sibling::dd[1]/a[1]'), 'href')
-    linknames <- xml_text(xml_find_all(y, '//dt/following-sibling::dd[1]/a[1]'))
+    links <- xml_attr(
+      xml_find_all(y, "//dt/following-sibling::dd[1]/a[1]"), "href")
+    linknames <- xml_text(xml_find_all(y, "//dt/following-sibling::dd[1]/a[1]"))
     return(data.frame(names, links, linknames, stringsAsFactors = FALSE))
   }
   # aw_idx <- rbind(prep_idx(idx1), prep_idx(idx2) ,prep_idx(idx3))
   aw_idx <- rbind(prep_idx(idx1))
-  aw_idx[['source']] <- 'rn'
-  idx4 <- read_html('http://www.alanwood.net/pesticides/index_cn.html')
-  n <- xml_find_all(idx4, '//a')
+  aw_idx[["source"]] <- "rn"
+  idx4 <- read_html("http://www.alanwood.net/pesticides/index_cn.html")
+  n <- xml_find_all(idx4, "//a")
   names <- xml_text(n)
-  rm <- names == ''
+  rm <- names == ""
   names <- names[!rm]
-  links <- xml_attr(n, 'href')
+  links <- xml_attr(n, "href")
   links <- links[!rm]
   idx4 <- data.frame(names = NA, links = links, linknames = names,
-                     source = 'cn', stringsAsFactors = FALSE)
+                     source = "cn", stringsAsFactors = FALSE)
   aw_idx <- rbind(aw_idx, idx4)
 
   # fix encoding
   ln <- aw_idx$linknames
-  Encoding(ln) <- 'latin1'
-  ln <- iconv(ln, from = 'latin1', to = 'ASCII', sub = '')
+  Encoding(ln) <- "latin1"
+  ln <- iconv(ln, from = "latin1", to = "ASCII", sub = "")
   aw_idx$linknames <- ln
-  attr(aw_idx, 'date') <- Sys.Date()
+  attr(aw_idx, "date") <- Sys.Date()
 
-  # save(aw_idx, file = 'data/aw_idx.rda')
+  # save(aw_idx, file = "data/aw_idx.rda")
   return(aw_idx)
 }

--- a/R/alanwood.R
+++ b/R/alanwood.R
@@ -64,7 +64,7 @@ aw_query <- function(query, type = c("commonname", "cas"), verbose = TRUE,
                   activity = NA,
                   subactivity = NA,
                   inchikey = NA,
-                  inch = NA,
+                  inchi = NA,
                   source_url = NA))
     }
     if (length(takelink) > 1) {

--- a/R/webchem-package.R
+++ b/R/webchem-package.R
@@ -1,5 +1,7 @@
 #' webchem: An R package to retrieve chemical information from the web.
 #'
+#' Chemical information from around the web. This package interacts with a suite
+#' of web APIs for chemical information.
 #'
 #' @docType package
 #' @name webchem

--- a/man/aw_idx.Rd
+++ b/man/aw_idx.Rd
@@ -4,13 +4,15 @@
 \name{aw_idx}
 \alias{aw_idx}
 \title{Index of Alan Woods Compendium of Pesticides}
-\format{A data frame with 2152 rows and 4 variables:
+\format{
+A data frame with 2152 rows and 4 variables:
 \describe{
   \item{names}{CAS numbers}
   \item{links}{URL to webpage}
   \item{linknames}{names in link / substance names}
   \item{source}{source of link, either from CAS (rn) or Commonname (cn)}
-}}
+}
+}
 \source{
 \url{http://www.alanwood.net/pesticides}
 }

--- a/man/aw_query.Rd
+++ b/man/aw_query.Rd
@@ -13,19 +13,23 @@ aw_query(query, type = c("commonname", "cas"), verbose = TRUE, idx = NULL)
 
 \item{verbose}{logical; print message during processing to console?}
 
-\item{idx}{data.frame; index to use. If NULL (default) the internal index \code{\link{aw_idx}} is used.
-To rebuild the index use \code{\link{build_aw_idx}}.}
+\item{idx}{data.frame; index to use. If NULL (default) the internal index
+\code{\link{aw_idx}} is used. To rebuild the index use
+\code{\link{build_aw_idx}}.}
 }
 \value{
-A list of eight entries: common-name, status, preferredd IUPAC Name,
-         IUPAC Name, cas, formula, activity, subactivity, inchikey, inchi and source url.
+A list of eight entries: common-name, status, preferred IUPAC Name,
+IUPAC Name, cas, formula, activity, subactivity, inchikey, inchi and source
+url.
 }
 \description{
-Query Alan Woods Compendium of Pesticide Common Names \url{http://www.alanwood.net/pesticides}
+Query Alan Woods Compendium of Pesticide Common Names
+\url{http://www.alanwood.net/pesticides}
 }
 \note{
 for type = 'cas' only the first matched link is returned.
-Please respect Copyright, Terms and Conditions \url{http://www.alanwood.net/pesticides/legal.html}!
+Please respect Copyright, Terms and Conditions
+\url{http://www.alanwood.net/pesticides/legal.html}!
 }
 \examples{
 \dontrun{

--- a/man/jagst.Rd
+++ b/man/jagst.Rd
@@ -4,13 +4,15 @@
 \name{jagst}
 \alias{jagst}
 \title{Organic plant protection products in the river Jagst / Germany in 2013}
-\format{A data frame with 442 rows and 4 variables:
+\format{
+A data frame with 442 rows and 4 variables:
 \describe{
   \item{date}{sampling data}
   \item{substance}{substance names}
   \item{value}{concentration in ug/L}
   \item{qual}{qualifier, indicating values < LOQ}
-}}
+}
+}
 \source{
 \url{http://jdkfg.lubw.baden-wuerttemberg.de/servlet/is/300/}
 }

--- a/man/lc50.Rd
+++ b/man/lc50.Rd
@@ -4,11 +4,13 @@
 \name{lc50}
 \alias{lc50}
 \title{Acute toxicity data from U.S. EPA ECOTOX}
-\format{A data frame with 124 rows and 2 variables:
+\format{
+A data frame with 124 rows and 2 variables:
 \describe{
   \item{cas}{CAS registry number}
   \item{value}{LC50value}
-}}
+}
+}
 \source{
 \url{http://cfpub.epa.gov/ecotox/}
 }

--- a/man/webchem.Rd
+++ b/man/webchem.Rd
@@ -5,5 +5,6 @@
 \alias{webchem}
 \title{webchem: An R package to retrieve chemical information from the web.}
 \description{
-webchem: An R package to retrieve chemical information from the web.
+Chemical information from around the web. This package interacts with a suite
+of web APIs for chemical information.
 }

--- a/tests/testthat/test-alanwood.R
+++ b/tests/testthat/test-alanwood.R
@@ -4,16 +4,16 @@ context("alanwood")
 test_that("alanwood, commonname", {
   skip_on_cran()
 
-  comps <- c('Fluazinam', "S-Metolachlor", "xxxxx")
-  o1 <- aw_query(comps, type = 'commonname')
+  comps <- c("Fluazinam", "S-Metolachlor", "xxxxx")
+  o1 <- aw_query(comps, type = "commonname")
 
-  expect_is(o1, 'list')
+  expect_is(o1, "list")
   expect_equal(length(o1), 3)
-  expect_true(is.na(o1[[3]]))
-  expect_equal(o1[['Fluazinam']]$cas, "79622-59-6")
+  expect_is(o1[[3]], "list")
+  expect_equal(o1[["Fluazinam"]]$cas, "79622-59-6")
   expect_equal(length(o1[["S-Metolachlor"]]$inchikey), 2)
   expect_equal(length(o1[["S-Metolachlor"]]$inchi), 2)
-  expect_equal(length(o1[['Fluazinam']]), 11)
+  expect_equal(length(o1[["Fluazinam"]]), 11)
 })
 
 
@@ -21,31 +21,31 @@ test_that("alanwood, cas", {
   skip_on_cran()
 
   comps <- c("79622-59-6", "87392-12-9", "xxxxx")
-  o1 <- aw_query(comps, type = 'cas')
+  o1 <- aw_query(comps, type = "cas")
 
-  expect_is(o1, 'list')
+  expect_is(o1, "list")
   expect_equal(length(o1), 3)
-  expect_true(is.na(o1[[3]]))
+  expect_is(o1[[3]], "list")
   expect_equal(o1[[1]]$cas, "79622-59-6")
   expect_equal(length(o1[[2]]$inchikey), 2)
   expect_equal(length(o1[[2]]$inchi), 2)
   expect_equal(length(o1[[1]]), 11)
-  expect_true(is.na(aw_query('12071-83-9', type = 'cas')[[1]]$inchi))
+  expect_true(is.na(aw_query("12071-83-9", type = "cas")[[1]]$inchi))
 })
 
 test_that("alanwood, build_index", {
   skip_on_cran()
 
   idx <- build_aw_idx()
-  expect_is(idx, 'data.frame')
+  expect_is(idx, "data.frame")
   expect_equal(ncol(idx), 4)
   expect_equal(names(idx), c("names", "links", "linknames", "source"))
   expect_equal(unique(idx$source), c("rn", "cn"))
-  expect_equal(idx$names[1], '50-00-0')
+  expect_equal(idx$names[1], "50-00-0")
 })
 
 test_that("alanwood index is up to date", {
   skip_on_cran()
 
-  expect_true(Sys.Date() - attr(aw_idx, 'date') < 90)
+  expect_true(Sys.Date() - attr(aw_idx, "date") < 90)
 })


### PR DESCRIPTION
`aw_query()` returned a list when a query was successful and `NA` when it wasn't. This disrupted the `apply()` functions. The updated function always returns a list but the elements are all `NA` when the query was not successful. Also updated style according to `lintr`.

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [ ] Check package passed