### PR TITLE
Fix get_cid to return NA when query is NA and style update

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ MINOR IMPROVEMENTS
 
 BUG FIXES
 
+* get_cid() returned the PubChem ID of sodium when the query was NA [PR #223, fixed by stitam]
 * aw_query() returned a list for successful queries, NA for unsuccessful queries [PR #222, fixed by stitam]
 
 DEPRECATED FUNCTIONS

--- a/R/chemspider.R
+++ b/R/chemspider.R
@@ -6,7 +6,7 @@
 #' ChemSpider database, you'll need to obtain an API key. Register at
 #' \url{https://developer.rsc.org/} for an API key. Please respect the Terms &
 #' Conditions \url{https://developer.rsc.org/terms}.
-#' @details You can store your API key as \code{CHEMSPIDER_KEY=<your key>} in
+#' @details You can store your API key as \code{CHEMSPIDER_KEY = <your key>} in
 #' .Renviron or as \code{options(chemspider_key = <your key>)} in .Rprofile.
 #' This will allow you to use ChemSpider without adding your API key in the
 #' beginning of each session, and will also allow you to share your analysis

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -5,22 +5,28 @@
 #' @import httr
 #' @importFrom stats rgamma
 #' @param query character; search term.
-#' @param from character; type of input, can be one of 'name' (default), 'cid', 'sid', 'aid', 'smiles', 'inchi', 'inchikey'
+#' @param from character; type of input, can be one of "name" (default), "cid",
+#' "sid", "aid", "smiles", "inchi", "inchikey"
 #' @param first logical; If TRUE return only first result.
 #' @param search_substances logical; If TRUE also searches PubChem SIDs
 #' @param verbose logical; should a verbose output be printed on the console?
-#' @param arg character; optinal arguments like 'name_type=word' to match individual words.
+#' @param arg character; optinal arguments like "name_type=word" to match
+#' individual words.
 #' @param ... optional arguments
 #' @return a list of cids. If first = TRUE a vector.
 #'
-#' @references Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public Information System for
-#' Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37: 623–633.
+#' @references Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public
+#' Information System for
+#' Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37:
+#' 623–633.
 #'
 #' Kim, Sunghwan, Paul A. Thiessen, Evan E. Bolton, et al. 2016
-#' PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1): D1202–D1213.
+#' PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1):
+#' D1202–D1213.
 #'
 #' Kim, S., Thiessen, P. A., Bolton, E. E., & Bryant, S. H. (2015).
-#' PUG-SOAP and PUG-REST: web services for programmatic access to chemical information in PubChem. Nucleic acids research, gkv396.
+#' PUG-SOAP and PUG-REST: web services for programmatic access to chemical
+#' information in PubChem. Nucleic acids research, gkv396.
 #' @note Please respect the Terms and Conditions of the National Library of
 #' Medicine, \url{https://www.nlm.nih.gov/databases/download.html} and the data
 #' usage policies of National Center for Biotechnology Information,
@@ -32,47 +38,50 @@
 #' @examples
 #' \donttest{
 #' # might fail if API is not available
-#' get_cid('Triclosan')
-#' get_cid('Triclosan', arg = 'name_type=word')
-#' get_cid("BPGDAMSIGCZZLK-UHFFFAOYSA-N", from = 'inchikey')
-#' get_cid("CCCC", from = 'smiles')
+#' get_cid("Triclosan")
+#' get_cid("Triclosan", arg = "name_type=word")
+#' get_cid("BPGDAMSIGCZZLK-UHFFFAOYSA-N", from = "inchikey")
+#' get_cid("CCCC", from = "smiles")
 #'
 #' # multiple inputs
-#' comp <- c('Triclosan', 'Aspirin')
+#' comp <- c("Triclosan", "Aspirin")
 #' get_cid(comp)
 #'
 #' }
-get_cid <- function(query, from = 'name', first = FALSE, search_substances = FALSE, verbose = TRUE, arg = NULL, ...) {
+get_cid <- function(query, from = "name", first = FALSE,
+                    search_substances = FALSE, verbose = TRUE,
+                    arg = NULL, ...) {
   # from can be cid | name | smiles | inchi | sdf | inchikey | formula
-  # query <- c('Aspirin')
-  # from = 'name'
+  # query <- c("Aspirin")
+  # from = "name"
 
-  foo <- function(query, from, first, scope = 'compound', verbose, ...){
-    prolog <- 'https://pubchem.ncbi.nlm.nih.gov/rest/pug'
-    input <- paste0('/',scope,'/', from)
-    output <- '/cids/JSON'
+  foo <- function(query, from, first, scope = "compound", verbose, ...) {
+    if (is.na(query)) return(NA)
+    prolog <- "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+    input <- paste0("/", scope, "/", from)
+    output <- "/cids/JSON"
     if (!is.null(arg))
-      arg <- paste0('?', arg)
+      arg <- paste0("?", arg)
     qurl <- paste0(prolog, input, output, arg)
     if (verbose)
       message(qurl)
-    Sys.sleep( rgamma(1, shape = 15, scale = 1/10))
+    Sys.sleep(rgamma(1, shape = 15, scale = 1 / 10))
     cont <- try(content(POST(qurl,
-                             body = paste0(from, '=', query)
-                             ), type = 'text', encoding = 'UTF-8'),
+                             body = paste0(from, "=", query)
+                             ), type = "text", encoding = "UTF-8"),
                 silent = TRUE
     )
     if (inherits(cont, "try-error")) {
-      warning('Problem with web service encountered... Returning NA.')
+      warning("Problem with web service encountered... Returning NA.")
       return(NA)
     }
     cont <- fromJSON(cont)
-    if (names(cont) == 'Fault') {
-      warning(cont$Fault$Details, '. Returning NA.')
+    if (names(cont) == "Fault") {
+      warning(cont$Fault$Details, ". Returning NA.")
       return(NA)
     }
 
-    if(scope=='substance'){
+    if (scope == "substance") {
       cont <- cont$InformationList$Information$CID
     }
 
@@ -88,8 +97,9 @@ get_cid <- function(query, from = 'name', first = FALSE, search_substances = FAL
   out <- lapply(query, foo, from = from, first = first, verbose = verbose)
   out <- setNames(out, query)
 
-  if(search_substances){
-  out2 <- lapply(query, foo, from = from, first = first, scope = 'substance', verbose = verbose)
+  if (search_substances) {
+  out2 <- lapply(query, foo, from = from, first = first, scope = "substance",
+                 verbose = verbose)
   out2 <- setNames(out2, query)
 
   out <- map2(out, out2, c)
@@ -97,7 +107,7 @@ get_cid <- function(query, from = 'name', first = FALSE, search_substances = FAL
   }
 
 
-  if (first){
+  if (first) {
     out <- unlist(out)
   }
 
@@ -108,27 +118,34 @@ get_cid <- function(query, from = 'name', first = FALSE, search_substances = FAL
 
 #' Retrieve compound properties from a pubchem CID
 #'
-#' Retrieve compound information from pubchem CID, see \url{https://pubchem.ncbi.nlm.nih.gov/}
+#' Retrieve compound information from pubchem CID, see
+#' \url{https://pubchem.ncbi.nlm.nih.gov/}
 #' @import httr jsonlite
 #'
 #' @param cid character; Pubchem ID (CID).
-#' @param properties character vector; properties to retrieve, e.g. c('MolecularFormula', 'MolecularWeight').
-#' If NULL (default) all available properties are retrieved.
-#' See \url{https://pubchem.ncbi.nlm.nih.gov/pug_rest/PUG_REST.html#_Toc409516770} for a list of all available properties.
+#' @param properties character vector; properties to retrieve, e.g.
+#' c("MolecularFormula", "MolecularWeight"). If NULL (default) all available
+#' properties are retrieved. See
+#' \url{https://pubchem.ncbi.nlm.nih.gov/pug_rest/PUG_REST.html#_Toc409516770}
+#' for a list of all available properties.
 #' @param verbose logical; should a verbose output be printed to the console?
 #' @param ... currently not used.
 #'
 #' @return a data.frame
 #' @author Eduard Szoecs, \email{eduardszoecs@@gmail.com}
 #' @seealso \code{\link{get_cid}} to retrieve Pubchem IDs.
-#' @references Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public Information System for
-#' Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37: 623–633.
+#' @references Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public
+#' Information System for
+#' Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37:
+#' 623–633.
 #'
 #' Kim, Sunghwan, Paul A. Thiessen, Evan E. Bolton, et al. 2016
-#' PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1): D1202–D1213.
+#' PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1):
+#' D1202–D1213.
 #'
 #' Kim, S., Thiessen, P. A., Bolton, E. E., & Bryant, S. H. (2015).
-#' PUG-SOAP and PUG-REST: web services for programmatic access to chemical information in PubChem. Nucleic acids research, gkv396.
+#' PUG-SOAP and PUG-REST: web services for programmatic access to chemical
+#' information in PubChem. Nucleic acids research, gkv396.
 #' @note Please respect the Terms and Conditions of the National Library of
 #' Medicine, \url{https://www.nlm.nih.gov/databases/download.html} and the data
 #' usage policies of National Center for Biotechnology Information,
@@ -142,51 +159,55 @@ get_cid <- function(query, from = 'name', first = FALSE, search_substances = FAL
 #'
 #' ###
 #' # multiple CIDS
-#' comp <- c('Triclosan', 'Aspirin')
+#' comp <- c("Triclosan", "Aspirin")
 #' cids <- unlist(get_cid(comp))
-#' pc_prop(cids, properties = c('MolecularFormula', 'MolecularWeight', 'CanonicalSMILES'))
+#' pc_prop(cids, properties = c("MolecularFormula", "MolecularWeight",
+#' "CanonicalSMILES"))
 #' }
-pc_prop <- function(cid, properties = NULL, verbose = TRUE, ...){
-  # cid <- c('5564', '7843')
+pc_prop <- function(cid, properties = NULL, verbose = TRUE, ...) {
+  # cid <- c("5564", "7843")
   napos <- which(is.na(cid))
   cid_o <- cid
   cid <- cid[!is.na(cid)]
-  prolog <- 'https://pubchem.ncbi.nlm.nih.gov/rest/pug'
-  input <- '/compound/cid'
+  prolog <- "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+  input <- "/compound/cid"
   if (is.null(properties))
-    properties <- c('MolecularFormula', 'MolecularWeight', 'CanonicalSMILES',
-                  'IsomericSMILES', 'InChI', 'InChIKey', 'IUPACName',
-                  'XLogP', 'ExactMass', 'MonoisotopicMass', 'TPSA',
-                  'Complexity', 'Charge', 'HBondDonorCount', 'HBondAcceptorCount',
-                  'RotatableBondCount', 'HeavyAtomCount', 'IsotopeAtomCount',
-                  'AtomStereoCount', 'DefinedAtomStereoCount', 'UndefinedAtomStereoCount',
-                  'BondStereoCount', 'DefinedBondStereoCount', 'UndefinedBondStereoCount',
-                  'CovalentUnitCount', 'Volume3D', 'XStericQuadrupole3D',
-                  'YStericQuadrupole3D', 'ZStericQuadrupole3D', 'FeatureCount3D',
-                  'FeatureAcceptorCount3D', 'FeatureDonorCount3D', 'FeatureAnionCount3D',
-                  'FeatureCationCount3D', 'FeatureRingCount3D', 'FeatureHydrophobeCount3D',
-                  'ConformerModelRMSD3D', 'EffectiveRotorCount3D', 'ConformerCount3D',
-                  'Fingerprint2D')
-  properties <- paste(properties, collapse = ',')
-  output <- paste0('/property/', properties, '/JSON')
+    properties <- c("MolecularFormula", "MolecularWeight", "CanonicalSMILES",
+                  "IsomericSMILES", "InChI", "InChIKey", "IUPACName",
+                  "XLogP", "ExactMass", "MonoisotopicMass", "TPSA",
+                  "Complexity", "Charge", "HBondDonorCount",
+                  "HBondAcceptorCount", "RotatableBondCount", "HeavyAtomCount",
+                  "IsotopeAtomCount", "AtomStereoCount",
+                  "DefinedAtomStereoCount", "UndefinedAtomStereoCount",
+                  "BondStereoCount", "DefinedBondStereoCount",
+                  "UndefinedBondStereoCount", "CovalentUnitCount", "Volume3D",
+                  "XStericQuadrupole3D", "YStericQuadrupole3D",
+                  "ZStericQuadrupole3D", "FeatureCount3D",
+                  "FeatureAcceptorCount3D", "FeatureDonorCount3D",
+                  "FeatureAnionCount3D", "FeatureCationCount3D",
+                  "FeatureRingCount3D", "FeatureHydrophobeCount3D",
+                  "ConformerModelRMSD3D", "EffectiveRotorCount3D",
+                  "ConformerCount3D", "Fingerprint2D")
+  properties <- paste(properties, collapse = ",")
+  output <- paste0("/property/", properties, "/JSON")
 
   qurl <- paste0(prolog, input, output)
   if (verbose)
     message(qurl)
   Sys.sleep(0.2)
   cont <- try(content(POST(qurl,
-                           body = list("cid" = paste(cid, collapse = ',')
+                           body = list("cid" = paste(cid, collapse = ",")
                                        )),
-                      type = 'text', encoding = 'UTF-8'),
+                      type = "text", encoding = "UTF-8"),
               silent = TRUE
   )
   if (inherits(cont, "try-error")) {
-    warning('Problem with web service encountered... Returning NA.')
+    warning("Problem with web service encountered... Returning NA.")
     return(NA)
   }
   cont <- fromJSON(cont)
-  if (names(cont) == 'Fault') {
-    warning(cont$Fault$Message, '. ', cont$Fault$Details, '. Returning NA.')
+  if (names(cont) == "Fault") {
+    warning(cont$Fault$Message, ". ", cont$Fault$Details, ". Returning NA.")
     return(NA)
   }
   out <- cont$PropertyTable[[1]]
@@ -207,7 +228,7 @@ pc_prop <- function(cid, properties = NULL, verbose = TRUE, ...){
       }
     }}
   rownames(out) <- NULL
-  class(out) <- c('pc_prop','data.frame')
+  class(out) <- c("pc_prop", "data.frame")
   return(out)
 }
 
@@ -220,23 +241,30 @@ pc_prop <- function(cid, properties = NULL, verbose = TRUE, ...){
 #' @importFrom utils menu
 #'
 #' @param query character; search term.
-#' @param from character; type of input, can be one of 'name' (default), 'cid',
-#'     'sid', 'aid', 'smiles', 'inchi', 'inchikey'
+#' @param from character; type of input, can be one of "name" (default), "cid",
+#'     "sid", "aid", "smiles", "inchi", "inchikey"
 #' @param interactive deprecated.  Use the \code{choices} argument instead
-#' @param choices to get only the first synonym, use \code{choices = 1}, to get a number of synonyms to choose from in an interactive menu, provide the number of choices you want or "all" to choose from all synonyms.
+#' @param choices to get only the first synonym, use \code{choices = 1}, to get
+#' a number of synonyms to choose from in an interactive menu, provide the
+#' number of choices you want or "all" to choose from all synonyms.
 #' @param verbose logical; should a verbose output be printed on the console?
-#' @param arg character; optinal arguments like 'name_type=word' to match individual words.
+#' @param arg character; optinal arguments like "name_type=word" to match
+#' individual words.
 #' @param ... optional arguments
 #' @return a character vector.
 #'
-#' @references Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public Information System for
-#' Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37: 623–633.
+#' @references Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public
+#' Information System for
+#' Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37:
+#' 623–633.
 #'
 #' Kim, Sunghwan, Paul A. Thiessen, Evan E. Bolton, et al. 2016
-#' PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1): D1202–D1213.
+#' PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1):
+#' D1202–D1213.
 #'
 #' Kim, S., Thiessen, P. A., Bolton, E. E., & Bryant, S. H. (2015).
-#' PUG-SOAP and PUG-REST: web services for programmatic access to chemical information in PubChem. Nucleic acids research, gkv396.
+#' PUG-SOAP and PUG-REST: web services for programmatic access to chemical
+#' information in PubChem. Nucleic acids research, gkv396.
 #' @note Please respect the Terms and Conditions of the National Library of
 #' Medicine, \url{https://www.nlm.nih.gov/databases/download.html} and the data
 #' usage policies of National Center for Biotechnology Information,
@@ -246,37 +274,38 @@ pc_prop <- function(cid, properties = NULL, verbose = TRUE, ...){
 #' @export
 #' @examples
 #' \donttest{
-#' pc_synonyms('Aspirin')
-#' pc_synonyms(c('Aspirin', 'Triclosan'))
-#' pc_synonyms(5564, from = 'cid')
-#' pc_synonyms(c('Aspirin', 'Triclosan'), choices = 10)
+#' pc_synonyms("Aspirin")
+#' pc_synonyms(c("Aspirin", "Triclosan"))
+#' pc_synonyms(5564, from = "cid")
+#' pc_synonyms(c("Aspirin", "Triclosan"), choices = 10)
 #' }
-pc_synonyms <- function(query, from = 'name', choices = NULL, verbose = TRUE, arg = NULL, interactive = 0, ...) {
+pc_synonyms <- function(query, from = "name", choices = NULL, verbose = TRUE,
+                        arg = NULL, interactive = 0, ...) {
   # from can be cid | name | smiles | inchi | sdf | inchikey | formula
-  # query <- c('Aspirin')
-  # from = 'name'
-  if(!missing("interactive"))
+  # query <- c("Aspirin")
+  # from = "name"
+  if (!missing("interactive"))
     stop("'interactive' is deprecated. Use 'choices' instead.")
-  foo <- function(query, from, verbose, ...){
-    prolog <- 'https://pubchem.ncbi.nlm.nih.gov/rest/pug'
-    input <- paste0('/compound/', from)
-    output <- '/synonyms/JSON'
+  foo <- function(query, from, verbose, ...) {
+    prolog <- "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+    input <- paste0("/compound/", from)
+    output <- "/synonyms/JSON"
     if (!is.null(arg))
-      arg <- paste0('?', arg)
+      arg <- paste0("?", arg)
     qurl <- paste0(prolog, input, output, arg)
     if (verbose)
       message(qurl)
     Sys.sleep(0.2)
     cont <- try(content(POST(qurl,
-                             body = paste0(from, '=', query)
+                             body = paste0(from, "=", query)
     )), silent = TRUE
     )
     if (inherits(cont, "try-error")) {
-      warning('Problem with web service encountered... Returning NA.')
+      warning("Problem with web service encountered... Returning NA.")
       return(NA)
     }
-    if (names(cont) == 'Fault') {
-      warning(cont$Fault$Details, '. Returning NA.')
+    if (names(cont) == "Fault") {
+      warning(cont$Fault$Details, ". Returning NA.")
       return(NA)
     }
     out <- unlist(cont)
@@ -287,10 +316,7 @@ pc_synonyms <- function(query, from = 'name', choices = NULL, verbose = TRUE, ar
   }
   out <- lapply(query, foo, from = from, verbose = verbose)
   out <- setNames(out, query)
-  if(!is.null(choices)) #if only one choice is returned, convert list to vector
+  if (!is.null(choices)) #if only one choice is returned, convert list to vector
     out <- unlist(out)
   return(out)
 }
-
-
-

--- a/man/cs_check_key.Rd
+++ b/man/cs_check_key.Rd
@@ -18,7 +18,7 @@ ChemSpider database, you'll need to obtain an API key. Register at
 \url{https://developer.rsc.org/} for an API key. Please respect the Terms &
 Conditions \url{https://developer.rsc.org/terms}.
 
-You can store your API key as \code{CHEMSPIDER_KEY=<your key>} in
+You can store your API key as \code{CHEMSPIDER_KEY = <your key>} in
 .Renviron or as \code{options(chemspider_key = <your key>)} in .Rprofile.
 This will allow you to use ChemSpider without adding your API key in the
 beginning of each session, and will also allow you to share your analysis

--- a/man/get_cid.Rd
+++ b/man/get_cid.Rd
@@ -17,7 +17,8 @@ get_cid(
 \arguments{
 \item{query}{character; search term.}
 
-\item{from}{character; type of input, can be one of 'name' (default), 'cid', 'sid', 'aid', 'smiles', 'inchi', 'inchikey'}
+\item{from}{character; type of input, can be one of "name" (default), "cid",
+"sid", "aid", "smiles", "inchi", "inchikey"}
 
 \item{first}{logical; If TRUE return only first result.}
 
@@ -25,7 +26,8 @@ get_cid(
 
 \item{verbose}{logical; should a verbose output be printed on the console?}
 
-\item{arg}{character; optinal arguments like 'name_type=word' to match individual words.}
+\item{arg}{character; optinal arguments like "name_type=word" to match
+individual words.}
 
 \item{...}{optional arguments}
 }
@@ -46,26 +48,30 @@ usage policies of National Center for Biotechnology Information,
 \examples{
 \donttest{
 # might fail if API is not available
-get_cid('Triclosan')
-get_cid('Triclosan', arg = 'name_type=word')
-get_cid("BPGDAMSIGCZZLK-UHFFFAOYSA-N", from = 'inchikey')
-get_cid("CCCC", from = 'smiles')
+get_cid("Triclosan")
+get_cid("Triclosan", arg = "name_type=word")
+get_cid("BPGDAMSIGCZZLK-UHFFFAOYSA-N", from = "inchikey")
+get_cid("CCCC", from = "smiles")
 
 # multiple inputs
-comp <- c('Triclosan', 'Aspirin')
+comp <- c("Triclosan", "Aspirin")
 get_cid(comp)
 
 }
 }
 \references{
-Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public Information System for
-Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37: 623–633.
+Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public
+Information System for
+Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37:
+623–633.
 
 Kim, Sunghwan, Paul A. Thiessen, Evan E. Bolton, et al. 2016
-PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1): D1202–D1213.
+PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1):
+D1202–D1213.
 
 Kim, S., Thiessen, P. A., Bolton, E. E., & Bryant, S. H. (2015).
-PUG-SOAP and PUG-REST: web services for programmatic access to chemical information in PubChem. Nucleic acids research, gkv396.
+PUG-SOAP and PUG-REST: web services for programmatic access to chemical
+information in PubChem. Nucleic acids research, gkv396.
 }
 \author{
 Eduard Szoecs, \email{eduardszoecs@gmail.com}

--- a/man/pc_prop.Rd
+++ b/man/pc_prop.Rd
@@ -9,9 +9,11 @@ pc_prop(cid, properties = NULL, verbose = TRUE, ...)
 \arguments{
 \item{cid}{character; Pubchem ID (CID).}
 
-\item{properties}{character vector; properties to retrieve, e.g. c('MolecularFormula', 'MolecularWeight').
-If NULL (default) all available properties are retrieved.
-See \url{https://pubchem.ncbi.nlm.nih.gov/pug_rest/PUG_REST.html#_Toc409516770} for a list of all available properties.}
+\item{properties}{character vector; properties to retrieve, e.g.
+c("MolecularFormula", "MolecularWeight"). If NULL (default) all available
+properties are retrieved. See
+\url{https://pubchem.ncbi.nlm.nih.gov/pug_rest/PUG_REST.html#_Toc409516770}
+for a list of all available properties.}
 
 \item{verbose}{logical; should a verbose output be printed to the console?}
 
@@ -21,7 +23,8 @@ See \url{https://pubchem.ncbi.nlm.nih.gov/pug_rest/PUG_REST.html#_Toc409516770} 
 a data.frame
 }
 \description{
-Retrieve compound information from pubchem CID, see \url{https://pubchem.ncbi.nlm.nih.gov/}
+Retrieve compound information from pubchem CID, see
+\url{https://pubchem.ncbi.nlm.nih.gov/}
 }
 \note{
 Please respect the Terms and Conditions of the National Library of
@@ -37,20 +40,25 @@ pc_prop(5564)
 
 ###
 # multiple CIDS
-comp <- c('Triclosan', 'Aspirin')
+comp <- c("Triclosan", "Aspirin")
 cids <- unlist(get_cid(comp))
-pc_prop(cids, properties = c('MolecularFormula', 'MolecularWeight', 'CanonicalSMILES'))
+pc_prop(cids, properties = c("MolecularFormula", "MolecularWeight",
+"CanonicalSMILES"))
 }
 }
 \references{
-Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public Information System for
-Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37: 623–633.
+Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public
+Information System for
+Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37:
+623–633.
 
 Kim, Sunghwan, Paul A. Thiessen, Evan E. Bolton, et al. 2016
-PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1): D1202–D1213.
+PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1):
+D1202–D1213.
 
 Kim, S., Thiessen, P. A., Bolton, E. E., & Bryant, S. H. (2015).
-PUG-SOAP and PUG-REST: web services for programmatic access to chemical information in PubChem. Nucleic acids research, gkv396.
+PUG-SOAP and PUG-REST: web services for programmatic access to chemical
+information in PubChem. Nucleic acids research, gkv396.
 }
 \seealso{
 \code{\link{get_cid}} to retrieve Pubchem IDs.

--- a/man/pc_synonyms.Rd
+++ b/man/pc_synonyms.Rd
@@ -17,14 +17,17 @@ pc_synonyms(
 \arguments{
 \item{query}{character; search term.}
 
-\item{from}{character; type of input, can be one of 'name' (default), 'cid',
-'sid', 'aid', 'smiles', 'inchi', 'inchikey'}
+\item{from}{character; type of input, can be one of "name" (default), "cid",
+"sid", "aid", "smiles", "inchi", "inchikey"}
 
-\item{choices}{to get only the first synonym, use \code{choices = 1}, to get a number of synonyms to choose from in an interactive menu, provide the number of choices you want or "all" to choose from all synonyms.}
+\item{choices}{to get only the first synonym, use \code{choices = 1}, to get
+a number of synonyms to choose from in an interactive menu, provide the
+number of choices you want or "all" to choose from all synonyms.}
 
 \item{verbose}{logical; should a verbose output be printed on the console?}
 
-\item{arg}{character; optinal arguments like 'name_type=word' to match individual words.}
+\item{arg}{character; optinal arguments like "name_type=word" to match
+individual words.}
 
 \item{interactive}{deprecated.  Use the \code{choices} argument instead}
 
@@ -46,21 +49,25 @@ usage policies of National Center for Biotechnology Information,
 }
 \examples{
 \donttest{
-pc_synonyms('Aspirin')
-pc_synonyms(c('Aspirin', 'Triclosan'))
-pc_synonyms(5564, from = 'cid')
-pc_synonyms(c('Aspirin', 'Triclosan'), choices = 10)
+pc_synonyms("Aspirin")
+pc_synonyms(c("Aspirin", "Triclosan"))
+pc_synonyms(5564, from = "cid")
+pc_synonyms(c("Aspirin", "Triclosan"), choices = 10)
 }
 }
 \references{
-Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public Information System for
-Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37: 623–633.
+Wang, Y., J. Xiao, T. O. Suzek, et al. 2009 PubChem: A Public
+Information System for
+Analyzing Bioactivities of Small Molecules. Nucleic Acids Research 37:
+623–633.
 
 Kim, Sunghwan, Paul A. Thiessen, Evan E. Bolton, et al. 2016
-PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1): D1202–D1213.
+PubChem Substance and Compound Databases. Nucleic Acids Research 44(D1):
+D1202–D1213.
 
 Kim, S., Thiessen, P. A., Bolton, E. E., & Bryant, S. H. (2015).
-PUG-SOAP and PUG-REST: web services for programmatic access to chemical information in PubChem. Nucleic acids research, gkv396.
+PUG-SOAP and PUG-REST: web services for programmatic access to chemical
+information in PubChem. Nucleic acids research, gkv396.
 }
 \author{
 Eduard Szoecs, \email{eduardszoecs@gmail.com}

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -3,39 +3,47 @@ context("pubchem")
 test_that("get_cid()", {
   skip_on_cran()
 
-  expect_equal(get_cid('Triclosan')[[1]], 5564)
-  expect_true(length(get_cid('Triclosan', arg = 'name_type=word')[[1]]) > 1)
-  expect_true(length(get_cid('Triclosan', arg = 'name_type=word', first = TRUE)[[1]]) == 1)
-  expect_true(length(get_cid(c('Triclosan', 'Aspirin'))) == 2)
-  expect_equal(get_cid('xxxxx', verbose = FALSE)[[1]], NA)
-  expect_equal(get_cid("BPGDAMSIGCZZLK-UHFFFAOYSA-N", from = 'inchikey')[[1]], 12345)
+  expect_equal(get_cid("Triclosan")[[1]], 5564)
+  expect_true(length(get_cid("Triclosan", arg = "name_type=word")[[1]]) > 1)
+  expect_true(length(get_cid("Triclosan", arg = "name_type=word",
+                             first = TRUE)[[1]]) == 1)
+  expect_true(length(get_cid(c("Triclosan", "Aspirin"))) == 2)
+  expect_true(is.na(get_cid("xxxx", verbose = FALSE)[[1]]))
+  expect_true(is.na(get_cid(NA)))
+  expect_equal(get_cid("BPGDAMSIGCZZLK-UHFFFAOYSA-N", from = "inchikey")[[1]],
+               12345)
 })
 
 
 test_that("pc_prop", {
   skip_on_cran()
 
-  a <- pc_prop('5564', properties = 'CanonicalSmiles', verbose = FALSE)
-  b <- pc_prop('xxx', properties = 'CanonicalSmiles', verbose = FALSE)
-  c <- pc_prop('5564', properties = c('CanonicalSmiles', 'InChiKey'), verbose = FALSE)
+  a <- pc_prop("5564", properties = "CanonicalSmiles", verbose = FALSE)
+  b <- pc_prop("xxx", properties = "CanonicalSmiles", verbose = FALSE)
+  c <- pc_prop("5564", properties = c("CanonicalSmiles", "InChiKey"),
+               verbose = FALSE)
   expect_equal(a$CanonicalSMILES, "C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl")
   expect_true(is.na(b))
-  expect_is(a, 'data.frame')
+  expect_is(a, "data.frame")
   expect_equal(ncol(c), 3)
 })
 
 test_that("pc_synonyms", {
   skip_on_cran()
 
-  expect_equal(pc_synonyms('Triclosan')[[1]][1], '5564')
-  expect_equal(length(pc_synonyms(c('Triclosan', 'Aspirin'))), 2)
-  expect_equal(pc_synonyms("BPGDAMSIGCZZLK-UHFFFAOYSA-N", from = 'inchikey')[[1]][1], "12345")
-  expect_true(is.na(pc_synonyms('xxxxx')[[1]]))
+  expect_equal(pc_synonyms("Triclosan")[[1]][1], "5564")
+  expect_equal(length(pc_synonyms(c("Triclosan", "Aspirin"))), 2)
+  expect_equal(pc_synonyms("BPGDAMSIGCZZLK-UHFFFAOYSA-N",
+                           from = "inchikey")[[1]][1], "12345")
+  expect_true(is.na(pc_synonyms("xxxx")[[1]]))
 })
 
 test_that("cid integration tests", {
   skip_on_cran()
 
-  expect_equal(pc_prop(get_cid('Triclosan')[[1]], properties = 'CanonicalSmiles')$CanonicalSMILES, "C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl")
-  expect_true(is.na(pc_prop(NA, properties = 'CanonicalSmiles', verbose = FALSE)))
+  expect_equal(pc_prop(get_cid("Triclosan")[[1]],
+                       properties = "CanonicalSmiles")$CanonicalSMILES,
+               "C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl")
+  expect_true(is.na(pc_prop(NA, properties = "CanonicalSmiles",
+                            verbose = FALSE)))
 })


### PR DESCRIPTION
Most of the PR is just style update according to `lintr::lint()`. The real difference is in line 59 of pubchem.R. `get_cid()` returned the Pubchem ID of sodium when the query was `NA`.

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed