### PR TITLE
Update AppVeyor and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache: packages
 env:
   global:
     - _R_CRAN_CHECK_INCOMING_=false
-r_check_args: "--no-build-vignettes --no-manual --timings --as-cran"
+r_check_args: "--no-build-vignettes --no-manual --timings --as-cran --no-examples"
 r_check_revdep: false
 warnings_are_errors: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
     R_BUILD_ARGS: --no-manual
-    R_CHECK_ARGS: --no-build-vignettes --no-manual --timings --as-cran --no-multiarch
+    R_CHECK_ARGS: --no-build-vignettes --no-manual --timings --as-cran --no-multiarch --no-dont_test
     R_INSTALL_ARGS: --no-multiarch
     PKGTYPE: binary
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
     R_BUILD_ARGS: --no-manual
-    R_CHECK_ARGS: --no-build-vignettes --no-manual --timings --as-cran --no-multiarch --no-dont_test
+    R_CHECK_ARGS: --no-build-vignettes --no-manual --timings --as-cran --no-multiarch --no-examples
     R_INSTALL_ARGS: --no-multiarch
     PKGTYPE: binary
 


### PR DESCRIPTION
Whenever a webservice is down, AppVeyor and Travis return errors because they are unable to run some of the examples. AppVeyor and Travis seem to run donttest examples as well by default and I could not find a way to turn this off so I removed all example checks to see if this fixes the build errors.