### PR TITLE
Add citation to nist_ri

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Authors@R: c(person("Eduard", "Szöcs", role = "aut"),
     person("Andreas", "Scharmüller", role = "ctb"),        
     person("Eric R", "Scott", role = "ctb"),
     person("Jan", "Stanstrup", role = "ctb"),
+    person("João Vitor", "F Cavalcante", role = "ctb"),
     person("Gordon", "Getzinger", role = "ctb"),
     person("Tamás", "Stirling", email = "stirling.tamas@gmail.com", role = c("ctb", "cre")))
 Maintainer: Tamás Stirling <stirling.tamas@gmail.com>

--- a/R/nist.R
+++ b/R/nist.R
@@ -309,7 +309,7 @@ tidy_ritable <- function(ri_xml) {
 #'   "Retention Indices" in NIST Chemistry WebBook, NIST Standard Reference
 #'   Database Number 69, Eds. P.J. Linstrom and W.G. Mallard,
 #'   National Institute of Standards and Technology, Gaithersburg MD, 20899,
-#'   https://doi.org/10.18434/T4D303.
+#'   \url{https://doi.org/10.18434/T4D303}.
 #'
 #' @export
 #' @note Copyright for NIST Standard Reference Data is governed by the Standard

--- a/R/nist.R
+++ b/R/nist.R
@@ -305,6 +305,12 @@ tidy_ritable <- function(ri_xml) {
 #'       were aggregated from}
 #'}
 #'
+#' @references NIST Mass Spectrometry Data Center, William E. Wallace, director,
+#'   "Retention Indices" in NIST Chemistry WebBook, NIST Standard Reference
+#'   Database Number 69, Eds. P.J. Linstrom and W.G. Mallard,
+#'   National Institute of Standards and Technology, Gaithersburg MD, 20899,
+#'   https://doi.org/10.18434/T4D303.
+#'
 #' @export
 #' @note Copyright for NIST Standard Reference Data is governed by the Standard
 #' Reference Data Act, \url{https://www.nist.gov/srd/public-law}.

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ At least some of the data in the following sources is accesible through `webchem
 - [ChEBI](https://www.ebi.ac.uk/chebi/)
 - [Chemical Identifier Resolver (CIR)](http://cactus.nci.nih.gov/chemical/structure)
 - [Chemical Translation Service (CTS)](http://cts.fiehnlab.ucdavis.edu/)
-- [ChemIDplus](http://chem.sis.nlm.nih.gov/chemidplus/) 
+- [ChemIDplus](https://chem.nlm.nih.gov/chemidplus/) 
 - [ChemSpider](http://www.chemspider.com/) (requires an [API token]((https://developer.rsc.org/)))
 - [ETOX](http://webetox.uba.de/webETOX/index.do)
 - [Flavornet](http://www.flavornet.org) 

--- a/man/nist_ri.Rd
+++ b/man/nist_ri.Rd
@@ -77,6 +77,13 @@ myRIs <- nist_ri(c("78-70-6", "13474-59-4"), from = "cas", "linear",
 "non-polar", "ramp")
 }
 }
+\references{
+NIST Mass Spectrometry Data Center, William E. Wallace, director,
+  "Retention Indices" in NIST Chemistry WebBook, NIST Standard Reference
+  Database Number 69, Eds. P.J. Linstrom and W.G. Mallard,
+  National Institute of Standards and Technology, Gaithersburg MD, 20899,
+  https://doi.org/10.18434/T4D303.
+}
 \seealso{
 \code{\link{is.cas}} \code{\link{as.cas}}
 }

--- a/man/nist_ri.Rd
+++ b/man/nist_ri.Rd
@@ -82,7 +82,7 @@ NIST Mass Spectrometry Data Center, William E. Wallace, director,
   "Retention Indices" in NIST Chemistry WebBook, NIST Standard Reference
   Database Number 69, Eds. P.J. Linstrom and W.G. Mallard,
   National Institute of Standards and Technology, Gaithersburg MD, 20899,
-  https://doi.org/10.18434/T4D303.
+  \url{https://doi.org/10.18434/T4D303}.
 }
 \seealso{
 \code{\link{is.cas}} \code{\link{as.cas}}


### PR DESCRIPTION
* Adds citation to the nist_ri() function, as described in #290 
* Changes ChemIDPlus link in the README, because the [previous one](http://chem.sis.nlm.nih.gov/chemidplus/) seemed to lead nowhere.

Couldn't easily find any other cases of missing references, if I've missed any, feel free to point out and I'll push more commits to this branch!

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [ ] Check package passed