### PR TITLE
Documentation fix for get_cid()

### DIFF
--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -6,7 +6,7 @@
 #' @param domain character; query domain, can be one of \code{"compound"},
 #' \code{"substance"}, \code{"assay"}.
 #' @param match character; How should multiple hits be handled?, \code{"all"}
-#' all matches are returned, \code{"best"} the best matching is returned,
+#' all matches are returned, \code{"first"} the first matching is returned,
 #' \code{"ask"} enters an interactive mode and the user is asked for input,
 #' \code{"na"} returns NA if multiple hits are found.
 #' @param verbose logical; should a verbose output be printed on the console?

--- a/man/get_cid.Rd
+++ b/man/get_cid.Rd
@@ -24,7 +24,7 @@ get_cid(
 \code{"substance"}, \code{"assay"}.}
 
 \item{match}{character; How should multiple hits be handled?, \code{"all"}
-all matches are returned, \code{"best"} the best matching is returned,
+all matches are returned, \code{"first"} the first matching is returned,
 \code{"ask"} enters an interactive mode and the user is asked for input,
 \code{"na"} returns NA if multiple hits are found.}
 


### PR DESCRIPTION
To make it consistent with the function definition. I think this does not warrant a NEWS entry. I did run devtools::check(run_dont_test = FALSE) and I got 

...
✔  checking examples with --run-donttest (3m 16.1s)
...

The tests took more then 10 minutes and got me

══ testthat results  ═══════════════════════════════════════════════════════════
[ OK: 350 | SKIPPED: 0 | WARNINGS: 6 | FAILED: 17 ]

I think there should be a warning that this takes a long time in your contribution notes for pull requests....

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [ ] Check package passed