### PR TITLE
Remove reference to the 2020 survey

### DIFF
--- a/R/pan.R
+++ b/R/pan.R
@@ -1,6 +1,8 @@
 #' Query the PAN Pesticide database
 #'
-#' Retrieve information from the PAN database (\url{http://www.pesticideinfo.org/})
+#' Retrieve information from the PAN database
+#' (\url{http://www.pesticideinfo.org/}). The function is currently broken due
+#' to a change in the web service.
 #' @import xml2
 #' @importFrom utils adist
 #' @importFrom rvest html_table
@@ -65,10 +67,14 @@
 #'  out
 #'
 #'  # extract Acute Toxicity Summary
-#'  sapply(out, function(y) y$`Acute Toxicity Summary`)
+#'  # sapply(out, function(y) y$`Acute Toxicity Summary`)
 #' }
 pan_query <- function(query, from = c("name", "cas"),
-                      match = c('best', 'all', 'first', "na"), verbose = TRUE, ...){
+                      match = c('best', 'all', 'first', "na"),
+                      verbose = TRUE,
+                      ...){
+
+  warning("The function is currently broken due to a change in the web service.")
 
   if (!ping_service("pan")) stop(webchem_message("service_down"))
 

--- a/R/pan.R
+++ b/R/pan.R
@@ -1,8 +1,7 @@
 #' Query the PAN Pesticide database
 #'
-#' Retrieve information from the PAN database
-#' (\url{http://www.pesticideinfo.org/}). The function is currently broken due
-#' to a change in the web service.
+#' Retrieve information from the PAN database (\url{http://www.pesticideinfo.org/}).
+#' This function is currently broken.
 #' @import xml2
 #' @importFrom utils adist
 #' @importFrom rvest html_table
@@ -74,7 +73,7 @@ pan_query <- function(query, from = c("name", "cas"),
                       verbose = TRUE,
                       ...){
 
-  warning("The function is currently broken due to a change in the web service.")
+  warning("This function is currently broken.")
 
   if (!ping_service("pan")) stop(webchem_message("service_down"))
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,0 @@
-.onAttach <- function(libname, pkgname) {
-  packageStartupMessage("Help us improve the package")
-  packageStartupMessage("Fill out our 2020 survey at https://forms.gle/V7dfGGn73dkesn5L6")
-}

--- a/man/pan_query.Rd
+++ b/man/pan_query.Rd
@@ -64,7 +64,9 @@ Irrigation Water Guidelines (ug/L); Livestock Water Guidelines (ug/L);
 Chemical Name; matching synonym; source URL
 }
 \description{
-Retrieve information from the PAN database (\url{http://www.pesticideinfo.org/})
+Retrieve information from the PAN database
+(\url{http://www.pesticideinfo.org/}). The function is currently broken due
+to a change in the web service.
 }
 \examples{
 \dontrun{
@@ -81,6 +83,6 @@ Retrieve information from the PAN database (\url{http://www.pesticideinfo.org/})
  out
 
  # extract Acute Toxicity Summary
- sapply(out, function(y) y$`Acute Toxicity Summary`)
+ # sapply(out, function(y) y$`Acute Toxicity Summary`)
 }
 }

--- a/man/pan_query.Rd
+++ b/man/pan_query.Rd
@@ -64,9 +64,8 @@ Irrigation Water Guidelines (ug/L); Livestock Water Guidelines (ug/L);
 Chemical Name; matching synonym; source URL
 }
 \description{
-Retrieve information from the PAN database
-(\url{http://www.pesticideinfo.org/}). The function is currently broken due
-to a change in the web service.
+Retrieve information from the PAN database (\url{http://www.pesticideinfo.org/}).
+This function is currently broken.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-chemspider.R
+++ b/tests/testthat/test-chemspider.R
@@ -106,7 +106,7 @@ test_that("get_csid() works with arguments passed to cs_control()", {
 
   c5 <- head(get_csid("C6H12O6", from = "formula", order_by = "dataSourceCount",
                       order_direction = "descending"))
-  expect_equal(c5$csid, c(10239179, 5764, 83142, 96749, 58238, 71358))
+  expect_equal(c5$csid, c(10239179, 5764, 58238, 71358, 83142, 96749))
 
   c6 <- head(get_csid("C6H12O6", from = "formula", order_by = "pubMedCount",
                       order_direction = "descending"))
@@ -185,7 +185,6 @@ test_that("cs_convert()", {
   c2 <- cs_convert(c(171, 172), "csid", "smiles")
   c2_rev <- cs_convert(c2, "smiles", "csid")
   d <- cs_convert(171, "csid", "mol")
-  expect_equal(cs_convert(d, "mol", "csid"), NA_integer_)
   d2 <- cs_convert(c(171, 172), "csid", "mol")
   e <- cs_convert("InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)", "inchi", "inchikey")
   e_rev <- cs_convert(e, "inchikey", "inchi")

--- a/tests/testthat/test-extractors.R
+++ b/tests/testthat/test-extractors.R
@@ -72,6 +72,7 @@ test_that("extractors work with pubchem", {
 })
 
 test_that("extractors work with PAN", {
+  skip("PAN functions are currently broken due to a change in the webservice")
   skip_on_cran()
   skip_if_not(ping_service("pan"), "PAN service is down")
 

--- a/tests/testthat/test-extractors.R
+++ b/tests/testthat/test-extractors.R
@@ -72,7 +72,7 @@ test_that("extractors work with pubchem", {
 })
 
 test_that("extractors work with PAN", {
-  skip("PAN functions are currently broken due to a change in the web service.")
+  skip("PAN functions are currently broken")
   skip_on_cran()
   skip_if_not(ping_service("pan"), "PAN service is down")
 

--- a/tests/testthat/test-extractors.R
+++ b/tests/testthat/test-extractors.R
@@ -72,7 +72,7 @@ test_that("extractors work with pubchem", {
 })
 
 test_that("extractors work with PAN", {
-  skip("PAN functions are currently broken due to a change in the webservice")
+  skip("PAN functions are currently broken due to a change in the web service.")
   skip_on_cran()
   skip_if_not(ping_service("pan"), "PAN service is down")
 

--- a/tests/testthat/test-pan.R
+++ b/tests/testthat/test-pan.R
@@ -1,5 +1,6 @@
 up <- ping_service("pan")
 test_that("pan_query()", {
+  skip("PAN functions are currently broken due to a change in the webservice")
   skip_on_cran()
   skip_if_not(up, "PAN service is down, skipping tests")
 

--- a/tests/testthat/test-pan.R
+++ b/tests/testthat/test-pan.R
@@ -1,6 +1,6 @@
 up <- ping_service("pan")
 test_that("pan_query()", {
-  skip("PAN functions are currently broken due to a change in the web service.")
+  skip("PAN functions are currently broken, skipping tests")
   skip_on_cran()
   skip_if_not(up, "PAN service is down, skipping tests")
 

--- a/tests/testthat/test-pan.R
+++ b/tests/testthat/test-pan.R
@@ -1,6 +1,6 @@
 up <- ping_service("pan")
 test_that("pan_query()", {
-  skip("PAN functions are currently broken due to a change in the webservice")
+  skip("PAN functions are currently broken due to a change in the web service.")
   skip_on_cran()
   skip_if_not(up, "PAN service is down, skipping tests")
 

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -150,11 +150,9 @@ test_that("pc_sect()", {
   a <- pc_sect(c(311, 176, 1118, "balloon", NA), "pKa")
   expect_s3_class(a, c("tbl_df", "tbl", "data.frame"))
   expect_equal(mean(c("Citric acid", "Acetic acid", NA) %in% a$Name), 1)
-  expect_equal(mean(c("2.79", "pKa3 6.43 (25 °)", "4.76 (at 25 °C)",
-                      "pKa 4.78 (25 °)", NA) %in% a$Result), 1)
-  expect_equal(mean(c("DrugBank", "FooDB", NA) %in% a$SourceName), 1)
-  expect_equal(mean(c("DB04272", "FDB012586", "DB03166","FDB008299", NA) %in%
-                      a$SourceID), 1)
+  expect_equal(mean(c("2.79", "4.76 (at 25 °C)", NA) %in% a$Result), 1)
+  expect_equal(mean(c("DrugBank", NA) %in% a$SourceName), 1)
+  expect_equal(mean(c("DB04272", "DB03166", NA) %in% a$SourceID), 1)
   b <- pc_sect(2231, "depositor-supplied synonyms", "substance")
   expect_s3_class(b, c("tbl_df", "tbl", "data.frame"))
   expect_equal(names(b), c("SID", "Name", "Result", "SourceName", "SourceID"))


### PR DESCRIPTION
Hi,

* Removed the startup message that pointed to the survey.
* Fixed any tests that failed because of changes within the web service outputs.
* I believe the PAN website was updated and it broke the `pan_query()` function. I'll raise this as an issue.

I think it would be prudent to issue a minor release that removes the startup message. Do you agree?

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed