### PR TITLE
Use names instead of stats::setNames

### DIFF
--- a/R/alanwood.R
+++ b/R/alanwood.R
@@ -158,7 +158,7 @@ aw_query <- function(query, from = c("name", "cas"), verbose = TRUE,
     }
   }
   out <- lapply(query, function(x) foo(x, from = from, verbose = verbose))
-  out <- setNames(out, query)
+  names(out) <- query
   class(out) <- c("aw_query", "list")
   return(out)
 }

--- a/R/chemid.R
+++ b/R/chemid.R
@@ -232,7 +232,7 @@ ci_query <- function(query, from = c('name', 'rn', 'inchikey', 'cas'),
     }
   }
   out <- lapply(query, foo, from = from, match = match, verbose = verbose)
-  out <- setNames(out, query)
+  names(out) <- query
   class(out) <- c('ci_query', 'list')
   return(out)
 }

--- a/R/cir.R
+++ b/R/cir.R
@@ -172,7 +172,7 @@ cir_query <- function(identifier, representation = "smiles",
   }
   out <- lapply(identifier, foo, representation = representation,
                 resolver = resolver, first = first, verbose = verbose)
-  out <- setNames(out, identifier)
+  names(out) <- identifier
   return(out)
 }
 

--- a/R/etox.R
+++ b/R/etox.R
@@ -447,6 +447,6 @@ etox_tests <- function(id, verbose = TRUE) {
     }
   }
   out <- lapply(id, foo, verbose = verbose)
-  names(out <- id)
+  names(out) <- id
   return(out)
 }

--- a/R/etox.R
+++ b/R/etox.R
@@ -251,7 +251,7 @@ etox_basic <- function(id, verbose = TRUE) {
     }
     }
   out <- lapply(id, foo, verbose = verbose)
-  out <- setNames(out, id)
+  names(out) <- id
   class(out) <- c('etox_basic', 'list')
   return(out)
 }
@@ -355,7 +355,7 @@ etox_targets <- function(id, verbose = TRUE) {
     }
   }
   out <- lapply(id, foo, verbose = verbose)
-  out <- setNames(out, id)
+  names(out) <- id
   return(out)
 }
 
@@ -447,6 +447,6 @@ etox_tests <- function(id, verbose = TRUE) {
     }
   }
   out <- lapply(id, foo, verbose = verbose)
-  out <- setNames(out, id)
+  names(out <- id)
   return(out)
 }

--- a/R/flavornet.R
+++ b/R/flavornet.R
@@ -63,6 +63,6 @@ fn_percept <- function(query, from = "cas", verbose = TRUE, CAS, ...)
     }
   }
   percepts <- sapply(query, foo, verbose = verbose)
-  percepts <- setNames(percepts, query)
+  names(percepts) <- query
   return(percepts)
 }

--- a/R/integration.R
+++ b/R/integration.R
@@ -105,7 +105,7 @@ find_db <- function(query, from,
   }
 
   out <- lapply(sources, foo, query = query, from = from)
-  out <- setNames(out, names(sources))
+  names(out) <- names(sources)
   out <- dplyr::bind_cols(query = query, out)
 
   if (plot) {

--- a/R/nist.R
+++ b/R/nist.R
@@ -355,7 +355,7 @@ nist_ri <- function(query,
 
   querynames <- query
   querynames [is.na(querynames)] <- ".NA"
-  ri_xmls <- setNames(ri_xmls, querynames)
+  names(ri_xmls) <- querynames
 
   ri_tables <- purrr::map_dfr(ri_xmls, tidy_ritable, .id = "query") %>%
     dplyr::mutate(query = na_if(query, ".NA"))

--- a/R/pan.R
+++ b/R/pan.R
@@ -162,7 +162,7 @@ pan_query <- function(query, from = c("name", "cas"),
     }
   }
   out <- lapply(query, foo, match = match, from = from, verbose = verbose)
-  out <- setNames(out, query)
+  names(out) <- query
   class(out) <- c('pan_query', 'list')
   return(out)
 }

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -501,7 +501,7 @@ pc_synonyms <- function(query,
     }
   }
   out <- lapply(query, foo, from = from, verbose = verbose)
-  out <- setNames(out, query)
+  names(out) <- query
   if (!is.null(choices)) #if only one choice is returned, convert list to vector
     out <- unlist(out)
   return(out)


### PR DESCRIPTION
webchem used three functions from the `stats` package, `rexp()`, `rgamma()`, `setNames()`. The first two were removed with PR #300 so now I'm proposing to remove `setNames` as well to reduce the number of packages webchem depends on.

PR task list:
- [x] Update documentation with `devtools::document()`
- [x] Check package passed