### PR TITLE
Activate testthat 3rd edition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,3 +52,5 @@ Suggests:
     usethis
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
+Config/testthat/edition:3
+Config/testthat/parallel:true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# webchem 1.1.1.9000
+
+## MINOR IMPROVEMENTS
+
+* webchem functions now default to global options regarding verbose messages.
+
 # webchem 1.1.1.
 
 ## NEW FEATURES

--- a/R/alanwood.R
+++ b/R/alanwood.R
@@ -31,7 +31,8 @@
 #' # use CAS-numbers
 #' aw_query("79622-59-6", from = 'cas')
 #' }
-aw_query <- function(query, from = c("name", "cas"), verbose = TRUE,
+aw_query <- function(query, from = c("name", "cas"),
+                     verbose = getOption("verbose"),
                      type, ...) {
 
   if (!ping_service("aw")) stop(webchem_message("service_down"))
@@ -176,7 +177,7 @@ aw_query <- function(query, from = c("name", "cas"), verbose = TRUE,
 #' @seealso \code{\link{aw_query}}, \code{\link{tempdir}}
 #' @source \url{http://www.alanwood.net/pesticides/}
 #' @noRd
-build_aw_idx <- function(verbose = TRUE, force_build = FALSE) {
+build_aw_idx <- function(verbose = getOption("verbose"), force_build = FALSE) {
   if (!ping_service("aw")) stop(webchem_message("service_down"))
   suppressWarnings(try(load(paste0(tempdir(), "/data/aw_idx.rda")),
                        silent = TRUE))

--- a/R/chebi.R
+++ b/R/chebi.R
@@ -73,7 +73,7 @@ get_chebiid <- function(query,
                         match = c("all", "best", "first", "ask", "na"),
                         max_res = 200,
                         stars =  c('all', 'two only', 'three only'),
-                        verbose = TRUE,
+                        verbose = getOption("verbose"),
                         ...) {
 
   if (!ping_service("chebi")) stop(webchem_message("service_down"))
@@ -134,7 +134,7 @@ get_chebiid <- function(query,
       names(out) <- tolower(names(out))
       out <- as_tibble(out)
       if (nrow(out) == 0) {
-        webchem_message("not_found")
+        if (verbose) webchem_message("not_found")
         return(tibble::tibble("query" = query, "chebiid" = NA_character_))
       }
       if (nrow(out) > 0) out$query <- query
@@ -238,7 +238,7 @@ get_chebiid <- function(query,
 #'
 #' }
 chebi_comp_entity <- function(chebiid,
-                              verbose = TRUE,
+                              verbose = getOption("verbose"),
                               ...) {
 
   if (!ping_service("chebi")) stop(webchem_message("service_down"))

--- a/R/chemid.R
+++ b/R/chemid.R
@@ -53,7 +53,7 @@
 #' }
 ci_query <- function(query, from = c('name', 'rn', 'inchikey', 'cas'),
                      match = c('first', 'best', 'ask', 'na'),
-                     verbose = TRUE, type){
+                     verbose = getOption("verbose"), type){
 
   if (!ping_service("ci")) stop(webchem_message("service_down"))
 

--- a/R/cir.R
+++ b/R/cir.R
@@ -115,7 +115,7 @@
 cir_query <- function(identifier, representation = "smiles",
                       resolver = NULL,
                       match = c("all", "first", "ask", "na"),
-                      verbose = TRUE,
+                      verbose = getOption("verbose"),
                       choices = NULL,
                       ...){
 
@@ -262,7 +262,7 @@ cir_query <- function(identifier, representation = "smiles",
 #'         header = "My funky chemical structure..",
 #'         footer = "..is just so awesome!",
 #'         frame = 1,
-#'         verbose = TRUE)
+#'         verbose = getOption("verbose"))
 #'}
 #' @export
 #'
@@ -283,7 +283,7 @@ cir_img <- function(query,
                     header = NULL,
                     footer = NULL,
                     frame = NULL,
-                    verbose = TRUE,
+                    verbose = getOption("verbose"),
                     ...) {
 
   if (!ping_service("cir")) stop(webchem_message("service_down"))

--- a/R/cts.R
+++ b/R/cts.R
@@ -7,10 +7,12 @@
 #' @param verbose logical; should a verbose output be printed on the console?
 #' @param inchikey deprecated
 #' @return a list of lists (for each supplied inchikey):
-#' a list of 7. inchikey, inchicode, molweight, exactmass, formula, synonyms and externalIds
+#' a list of 7. inchikey, inchicode, molweight, exactmass, formula, synonyms and
+#' externalIds
 #'
-#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
-#' -- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+#' Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+#' Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 #' @export
 #' @examples
 #' \donttest{
@@ -28,7 +30,8 @@
 #' # extract molecular weight
 #' sapply(out2, function(y) y$molweight)
 #' }
-cts_compinfo <- function(query, from = "inchikey", verbose = TRUE, inchikey){
+cts_compinfo <- function(query, from = "inchikey",
+                         verbose = getOption("verbose"), inchikey){
 
   if (!ping_service("cts")) stop(webchem_message("service_down"))
 
@@ -77,12 +80,13 @@ cts_compinfo <- function(query, from = "inchikey", verbose = TRUE, inchikey){
 
 #' Convert Ids using Chemical Translation Service (CTS)
 #'
-#' Convert Ids using Chemical Translation Service (CTS), see \url{http://cts.fiehnlab.ucdavis.edu/}
+#' Convert Ids using Chemical Translation Service (CTS), see
+#' \url{http://cts.fiehnlab.ucdavis.edu/}
 #' @import jsonlite
 #' @importFrom utils URLencode
 #' @param query character; query ID.
-#' @param from character; type of query ID, e.g. \code{'Chemical Name'} , \code{'InChIKey'},
-#'  \code{'PubChem CID'}, \code{'ChemSpider'}, \code{'CAS'}.
+#' @param from character; type of query ID, e.g. \code{'Chemical Name'} ,
+#' \code{'InChIKey'}, \code{'PubChem CID'}, \code{'ChemSpider'}, \code{'CAS'}.
 #' @param to character; type to convert to.
 #' @param match character; How should multiple hits be handled? \code{"all"}
 #' returns all matches, \code{"first"} returns only the first result,
@@ -91,15 +95,17 @@ cts_compinfo <- function(query, from = "inchikey", verbose = TRUE, inchikey){
 #' @param choices deprecated.  Use the \code{match} argument instead.
 #' @param verbose logical; should a verbose output be printed on the console?
 #' @param ... currently not used.
-#' @return a list of character vectors or if \code{choices} is used, then a single named vector.
+#' @return a list of character vectors or if \code{choices} is used, then a
+#' single named vector.
 #' @details See also \url{http://cts.fiehnlab.ucdavis.edu/}
 #' for possible values of from and to.
 #'
-#' @seealso \code{\link{cts_from}} for possible values in the 'from' argument and
-#' \code{\link{cts_to}} for possible values in the 'to' argument.
+#' @seealso \code{\link{cts_from}} for possible values in the 'from' argument
+#' and \code{\link{cts_to}} for possible values in the 'to' argument.
 #'
-#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
-#' -- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+#' Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+#' Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 #' @export
 #' @examples
 #' \donttest{
@@ -114,7 +120,7 @@ cts_convert <- function(query,
                         from,
                         to,
                         match = c("all", "first", "ask", "na"),
-                        verbose = TRUE,
+                        verbose = getOption("verbose"),
                         choices = NULL,
                         ...){
 
@@ -136,7 +142,8 @@ cts_convert <- function(query,
     }
   }
   if (length(from) > 1 | length(to) > 1) {
-    stop('Cannot handle multiple input or output types.  Please provide only one argument for `from` and `to`.')
+    stop('Cannot handle multiple input or output types.  Please provide only one
+         argument for `from` and `to`.')
   }
 
   from <-  match.arg(tolower(from), c(cts_from(), "name"))
@@ -180,14 +187,16 @@ cts_convert <- function(query,
         return(NA)
       }
       out <- out$result[[1]]
-      out <- matcher(out, match = match, query = query, from = from, verbose = verbose)
+      out <- matcher(out, match = match, query = query, from = from,
+                     verbose = verbose)
       return(out)
     }
     else {
       return(NA)
     }
   }
-  out <- lapply(query, foo, from = from, to = to, first = first, verbose = verbose)
+  out <- lapply(query, foo, from = from, to = to, first = first,
+                verbose = verbose)
   names(out) <- query
   return(out)
 }
@@ -203,14 +212,15 @@ cts_convert <- function(query,
 #'
 #' @seealso \code{\link{cts_convert}}
 #'
-#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
-#' -- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+#' Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+#' Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 #' @export
 #' @examples
 #' \donttest{
 #' cts_from()
 #' }
-cts_from <- function(verbose = TRUE){
+cts_from <- function(verbose = getOption("verbose")){
 
   if (!ping_service("cts")) stop(webchem_message("service_down"))
 
@@ -239,14 +249,15 @@ cts_from <- function(verbose = TRUE){
 #'
 #' @seealso \code{\link{cts_convert}}
 #'
-#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
-#' -- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+#' @references Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+#' Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+#' Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 #' @export
 #' @examples
 #' \donttest{
 #' cts_from()
 #' }
-cts_to <- function(verbose = TRUE){
+cts_to <- function(verbose = getOption("verbose")){
 
   if (!ping_service("cts")) stop(webchem_message("service_down"))
 

--- a/R/etox.R
+++ b/R/etox.R
@@ -42,7 +42,7 @@
 get_etoxid <- function(query,
                        from = c("name", "cas", "ec", "gsbl", "rtecs"),
                        match = c("all", "best", "first", "ask", "na"),
-                       verbose = TRUE) {
+                       verbose = getOption("verbose")) {
 
   if (!ping_service("etox")) stop(webchem_message("service_down"))
 
@@ -168,7 +168,7 @@ get_etoxid <- function(query,
 #' # extract cas numbers
 #' sapply(out, function(y) y$cas)
 #' }
-etox_basic <- function(id, verbose = TRUE) {
+etox_basic <- function(id, verbose = getOption("verbose")) {
 
   if (!ping_service("etox")) stop(webchem_message("service_down"))
 
@@ -194,7 +194,7 @@ etox_basic <- function(id, verbose = TRUE) {
     if (res$status_code == 200) {
       tt <- try(read_html(res), silent = TRUE)
       if (inherits(tt, 'try-error')) {
-        webchem_message("not_found")
+        if (verbose) webchem_message("not_found")
         return(NA)
       }
       tabs <- try(suppressWarnings(html_table(tt, fill = TRUE)), silent = TRUE)
@@ -289,7 +289,7 @@ etox_basic <- function(id, verbose = TRUE) {
 #' etox_targets( c("20179", "9051"))
 #'
 #' }
-etox_targets <- function(id, verbose = TRUE) {
+etox_targets <- function(id, verbose = getOption("verbose")) {
 
   if (!ping_service("etox")) stop(webchem_message("service_down"))
 
@@ -386,7 +386,7 @@ etox_targets <- function(id, verbose = TRUE) {
 #' 'Endpoint', 'Value', 'Unit')]
 #' etox_tests( c("20179", "9051"))
 #' }
-etox_tests <- function(id, verbose = TRUE) {
+etox_tests <- function(id, verbose = getOption("verbose")) {
 
   if (!ping_service("etox")) stop(webchem_message("service_down"))
 
@@ -412,7 +412,7 @@ etox_tests <- function(id, verbose = TRUE) {
     if (res$status_code == 200) {
       tt <- try(read_html(res), silent = TRUE)
       if (inherits(tt, 'try-error')) {
-        webchem_message("not_found")
+        if (verbose) webchem_message("not_found")
         return(NA)
       }
       link2 <- xml_attrs(xml_find_all(tt, "//a[contains(.,'Tests') and contains(@href,'stoff')]"), 'href')

--- a/R/flavornet.R
+++ b/R/flavornet.R
@@ -23,7 +23,8 @@
 #' }
 #' @export
 
-fn_percept <- function(query, from = "cas", verbose = TRUE, CAS, ...)
+fn_percept <- function(query, from = "cas", verbose = getOption("verbose"),
+                       CAS, ...)
 {
 
   if (!ping_service("fn")) stop(webchem_message("service_down"))

--- a/R/integration.R
+++ b/R/integration.R
@@ -22,7 +22,7 @@
 #' \dontrun{
 #' with_cts("XDDAORKBJWWYJS-UHFFFAOYSA-N", from = "inchikey", .f = "get_etoxid")
 #' }
-with_cts <- function(query, from, .f, .verbose = TRUE, ...) {
+with_cts <- function(query, from, .f, .verbose = getOption("verbose"), ...) {
   f <- rlang::as_function(.f)
   pos_froms <- eval(rlang::fn_fmls(f)$from)
 

--- a/R/nist.R
+++ b/R/nist.R
@@ -327,7 +327,7 @@ nist_ri <- function(query,
                     polarity = c("polar", "non-polar"),
                     temp_prog = c("isothermal", "ramp", "custom"),
                     cas = NULL,
-                    verbose = TRUE) {
+                    verbose = getOption("verbose")) {
 
   if (!is.null(cas)) {
     warning("`cas` is deprecated.  Using `query` instead with `from = 'cas'`.")

--- a/R/opsin.R
+++ b/R/opsin.R
@@ -24,7 +24,7 @@
 #'}
 #' @export
 
-opsin_query <- function(query, verbose = TRUE, ...){
+opsin_query <- function(query, verbose = getOption("verbose"), ...){
 
   if (!ping_service("opsin")) stop(webchem_message("service_down"))
 

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -116,7 +116,7 @@ get_cid <-
            from = "name",
            domain = c("compound", "substance", "assay"),
            match = c("all", "first", "ask", "na"),
-           verbose = TRUE,
+           verbose = getOption("verbose"),
            arg = NULL,
            first = NULL,
            ...) {
@@ -253,7 +253,8 @@ get_cid <-
         cont <- jsonlite::fromJSON(cont)$InformationList$Information$CID
       }
       out <- unique(unlist(cont))
-      out <- matcher(x = out, query = query, match = match, from = from, verbose = verbose)
+      out <- matcher(x = out, query = query, match = match, from = from,
+                     verbose = verbose)
       out <- as.character(out)
       return(tibble::tibble("query" = query, "cid" = out))
     }
@@ -317,7 +318,7 @@ get_cid <-
 #' pc_prop(cids$cid, properties = c("MolecularFormula", "MolecularWeight",
 #' "CanonicalSMILES"))
 #' }
-pc_prop <- function(cid, properties = NULL, verbose = TRUE, ...) {
+pc_prop <- function(cid, properties = NULL, verbose = getOption("verbose"), ...) {
 
   if (!ping_service("pc")) stop(webchem_message("service_down"))
 
@@ -449,7 +450,7 @@ pc_prop <- function(cid, properties = NULL, verbose = TRUE, ...) {
 pc_synonyms <- function(query,
                         from = c("name", "cid", "sid", "aid", "smiles", "inchi", "inchikey"),
                         match = c("all", "first", "ask", "na"),
-                        verbose = TRUE,
+                        verbose = getOption("verbose"),
                         arg = NULL, choices = NULL, ...) {
 
   if (!ping_service("pc")) stop(webchem_message("service_down"))
@@ -494,7 +495,8 @@ pc_synonyms <- function(query,
       out <- unlist(cont)[-1] #first result is always an ID number
       names(out) <- NULL
 
-      out <- matcher(out, query = query, match = match, from = from, verbose = verbose)
+      out <- matcher(out, query = query, match = match, from = from,
+                     verbose = verbose)
     }
     else {
       return(NA)
@@ -558,7 +560,7 @@ pc_sect <- function(id,
                     section,
                     domain = c("compound", "substance", "assay", "gene",
                                 "protein", "patent"),
-                    verbose = TRUE) {
+                    verbose = getOption("verbose")) {
   domain <- match.arg(domain)
   section <- tolower(gsub(" +", "+", section))
   if (section %in% c("standard non-polar",
@@ -604,7 +606,7 @@ pc_page <- function(id,
                     section,
                     domain = c("compound", "substance", "assay", "gene",
                                "protein", "patent"),
-                    verbose = TRUE) {
+                    verbose = getOption("verbose")) {
 
   if (!ping_service("pc")) stop(webchem_message("service_down"))
 

--- a/R/srs.R
+++ b/R/srs.R
@@ -27,7 +27,7 @@
 srs_query <-
   function(query,
            from = c("itn", "cas", "epaid", "tsn", "name"),
-           verbose = TRUE, ...) {
+           verbose = getOption("verbose"), ...) {
 
     if (!ping_service("srs")) stop(webchem_message("service_down"))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,7 +31,8 @@
 #' is.inchikey('BQJCRHHNABKAKU/KBQPJGBKSA/N')
 #' is.inchikey('BQJCRHHNABKAKU-KBQPJGBKXA-N')
 #' is.inchikey('BQJCRHHNABKAKU-KBQPJGBKSB-N')
-is.inchikey = function(x, type = c('format', 'chemspider'), verbose = TRUE) {
+is.inchikey = function(x, type = c('format', 'chemspider'),
+                       verbose = getOption("verbose")) {
   # x <- 'BQJCRHHNABKAKU-KBQPJGBKSA-N'
   if (length(x) > 1) {
     stop('Cannot handle multiple input strings.')
@@ -64,7 +65,7 @@ is.inchikey = function(x, type = c('format', 'chemspider'), verbose = TRUE) {
 #' is.inchikey_cs('BQJCRHHNABKAKU-KBQPJGBKXA-N')
 #' is.inchikey_cs('BQJCRHHNABKAKU-KBQPJGBKSB-N')
 #' }
-is.inchikey_cs <- function(x, verbose = TRUE){
+is.inchikey_cs <- function(x, verbose = getOption("verbose")){
 
   if (!ping_service("cs_web")) stop(webchem_message("service_down"))
 
@@ -128,7 +129,7 @@ is.inchikey_cs <- function(x, verbose = TRUE){
 #' is.inchikey_format('BQJCRHHNABKAKU-KBQPJGBKXA-N')
 #' is.inchikey_format('BQJCRHHNABKAKU-KBQPJGBKSB-N')
 #' }
-is.inchikey_format = function(x, verbose = TRUE) {
+is.inchikey_format = function(x, verbose = getOption("verbose")) {
   # x <- 'BQJCRHHNABKAKU-KBQPJGBKSA-N'
   if (length(x) > 1) {
     stop('Cannot handle multiple input strings.')
@@ -200,7 +201,7 @@ is.inchikey_format = function(x, verbose = TRUE) {
 #' is.cas('64-177-6')
 #' is.cas('64-17-55')
 #' is.cas('64-17-6')
-is.cas <-  function(x, verbose = TRUE) {
+is.cas <-  function(x, verbose = getOption("verbose")) {
 
   foo <- function(x, verbose) {
     # pass NA's through
@@ -282,7 +283,7 @@ is.cas <-  function(x, verbose = TRUE) {
 #' is.smiles('Clc(c(Cl)c(Cl)c1C(=O)O)c(Cl)c1Cl')
 #' is.smiles('Clc(c(Cl)c(Cl)c1C(=O)O)c(Cl)c1ClJ')
 #' }
-is.smiles <- function(x, verbose = TRUE) {
+is.smiles <- function(x, verbose = getOption("verbose")) {
   if (!requireNamespace("rcdk", quietly = TRUE)) {
     stop("rcdk needed for this function to work. Please install it.",
          call. = FALSE)
@@ -424,7 +425,7 @@ matcher <-
            result = NULL,
            match = c("all", "best", "first", "ask", "na"),
            from = NULL,
-           verbose = FALSE) {
+           verbose = getOption("verbose")) {
 
     match <- match.arg(match)
     names(x) <- result
@@ -436,7 +437,8 @@ matcher <-
 
       if (!is.null(from)) {
         if (!str_detect(tolower(from), "name") & match == "best") {
-          warning("match = 'best' only makes sense for chemical name queries.\n Setting match = 'first'.")
+          warning("match = 'best' only makes sense for chemical name queries.\n
+                  Setting match = 'first'.")
           match <- "first"
         }
       }

--- a/R/wikidata.R
+++ b/R/wikidata.R
@@ -34,7 +34,7 @@
 get_wdid <-
   function(query,
            match = c('best', 'first', 'all', 'ask', 'na'),
-           verbose = TRUE,
+           verbose = getOption("verbose"),
            language = 'en') {
 
     if (!ping_service("wd")) stop(webchem_message("service_down"))
@@ -146,7 +146,7 @@ get_wdid <-
 #'  id <- c("Q408646", "Q18216")
 #'  wd_ident(id)
 #' }
-wd_ident <- function(id, verbose = TRUE){
+wd_ident <- function(id, verbose = getOption("verbose")){
 
   if (!ping_service("wd")) stop(webchem_message("service_down"))
 

--- a/man/aw_query.Rd
+++ b/man/aw_query.Rd
@@ -4,7 +4,13 @@
 \alias{aw_query}
 \title{Query http://www.alanwood.net/pesticides/}
 \usage{
-aw_query(query, from = c("name", "cas"), verbose = TRUE, type, ...)
+aw_query(
+  query,
+  from = c("name", "cas"),
+  verbose = getOption("verbose"),
+  type,
+  ...
+)
 }
 \arguments{
 \item{query}{character; search string}

--- a/man/chebi_comp_entity.Rd
+++ b/man/chebi_comp_entity.Rd
@@ -4,7 +4,7 @@
 \alias{chebi_comp_entity}
 \title{Retrieve Complete Entity from ChEBI}
 \usage{
-chebi_comp_entity(chebiid, verbose = TRUE, ...)
+chebi_comp_entity(chebiid, verbose = getOption("verbose"), ...)
 }
 \arguments{
 \item{chebiid}{character; search term (i.e. chebiid).}

--- a/man/ci_query.Rd
+++ b/man/ci_query.Rd
@@ -8,7 +8,7 @@ ci_query(
   query,
   from = c("name", "rn", "inchikey", "cas"),
   match = c("first", "best", "ask", "na"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   type
 )
 }

--- a/man/cir_img.Rd
+++ b/man/cir_img.Rd
@@ -22,7 +22,7 @@ cir_img(
   header = NULL,
   footer = NULL,
   frame = NULL,
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   ...
 )
 }
@@ -120,7 +120,7 @@ cir_img(query,
         header = "My funky chemical structure..",
         footer = "..is just so awesome!",
         frame = 1,
-        verbose = TRUE)
+        verbose = getOption("verbose"))
 }
 }
 \references{

--- a/man/cir_query.Rd
+++ b/man/cir_query.Rd
@@ -9,7 +9,7 @@ cir_query(
   representation = "smiles",
   resolver = NULL,
   match = c("all", "first", "ask", "na"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   choices = NULL,
   ...
 )

--- a/man/cts_compinfo.Rd
+++ b/man/cts_compinfo.Rd
@@ -4,7 +4,12 @@
 \alias{cts_compinfo}
 \title{Get record details from Chemical Translation Service (CTS)}
 \usage{
-cts_compinfo(query, from = "inchikey", verbose = TRUE, inchikey)
+cts_compinfo(
+  query,
+  from = "inchikey",
+  verbose = getOption("verbose"),
+  inchikey
+)
 }
 \arguments{
 \item{query}{character; InChIkey.}
@@ -17,7 +22,8 @@ cts_compinfo(query, from = "inchikey", verbose = TRUE, inchikey)
 }
 \value{
 a list of lists (for each supplied inchikey):
-a list of 7. inchikey, inchicode, molweight, exactmass, formula, synonyms and externalIds
+a list of 7. inchikey, inchicode, molweight, exactmass, formula, synonyms and
+externalIds
 }
 \description{
 Get record details from CTS, see \url{http://cts.fiehnlab.ucdavis.edu/}
@@ -40,6 +46,7 @@ sapply(out2, function(y) y$molweight)
 }
 }
 \references{
-Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
--- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 }

--- a/man/cts_convert.Rd
+++ b/man/cts_convert.Rd
@@ -9,7 +9,7 @@ cts_convert(
   from,
   to,
   match = c("all", "first", "ask", "na"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   choices = NULL,
   ...
 )
@@ -17,8 +17,8 @@ cts_convert(
 \arguments{
 \item{query}{character; query ID.}
 
-\item{from}{character; type of query ID, e.g. \code{'Chemical Name'} , \code{'InChIKey'},
-\code{'PubChem CID'}, \code{'ChemSpider'}, \code{'CAS'}.}
+\item{from}{character; type of query ID, e.g. \code{'Chemical Name'} ,
+\code{'InChIKey'}, \code{'PubChem CID'}, \code{'ChemSpider'}, \code{'CAS'}.}
 
 \item{to}{character; type to convert to.}
 
@@ -34,10 +34,12 @@ returns all matches, \code{"first"} returns only the first result,
 \item{...}{currently not used.}
 }
 \value{
-a list of character vectors or if \code{choices} is used, then a single named vector.
+a list of character vectors or if \code{choices} is used, then a
+single named vector.
 }
 \description{
-Convert Ids using Chemical Translation Service (CTS), see \url{http://cts.fiehnlab.ucdavis.edu/}
+Convert Ids using Chemical Translation Service (CTS), see
+\url{http://cts.fiehnlab.ucdavis.edu/}
 }
 \details{
 See also \url{http://cts.fiehnlab.ucdavis.edu/}
@@ -54,10 +56,11 @@ cts_convert(comp, "Chemical Name", "cas")
 }
 }
 \references{
-Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
--- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 }
 \seealso{
-\code{\link{cts_from}} for possible values in the 'from' argument and
-\code{\link{cts_to}} for possible values in the 'to' argument.
+\code{\link{cts_from}} for possible values in the 'from' argument
+and \code{\link{cts_to}} for possible values in the 'to' argument.
 }

--- a/man/cts_from.Rd
+++ b/man/cts_from.Rd
@@ -4,7 +4,7 @@
 \alias{cts_from}
 \title{Return a list of all possible ids}
 \usage{
-cts_from(verbose = TRUE)
+cts_from(verbose = getOption("verbose"))
 }
 \arguments{
 \item{verbose}{logical; should a verbose output be printed on the console?}
@@ -24,8 +24,9 @@ cts_from()
 }
 }
 \references{
-Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
--- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 }
 \seealso{
 \code{\link{cts_convert}}

--- a/man/cts_to.Rd
+++ b/man/cts_to.Rd
@@ -4,7 +4,7 @@
 \alias{cts_to}
 \title{Return a list of all possible ids}
 \usage{
-cts_to(verbose = TRUE)
+cts_to(verbose = getOption("verbose"))
 }
 \arguments{
 \item{verbose}{logical; should a verbose output be printed on the console?}
@@ -24,8 +24,9 @@ cts_from()
 }
 }
 \references{
-Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O. Fiehn 2010The Chemical Translation Service
--- a Web-Based Tool to Improve Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
+Wohlgemuth, G., P. K. Haldiya, E. Willighagen, T. Kind, and O.
+Fiehn 2010The Chemical Translation Service -- a Web-Based Tool to Improve
+Standardization of Metabolomic Reports. Bioinformatics 26(20): 2647–2648.
 }
 \seealso{
 \code{\link{cts_convert}}

--- a/man/etox_basic.Rd
+++ b/man/etox_basic.Rd
@@ -4,7 +4,7 @@
 \alias{etox_basic}
 \title{Get basic information from a ETOX ID}
 \usage{
-etox_basic(id, verbose = TRUE)
+etox_basic(id, verbose = getOption("verbose"))
 }
 \arguments{
 \item{id}{character; ETOX ID}

--- a/man/etox_targets.Rd
+++ b/man/etox_targets.Rd
@@ -4,7 +4,7 @@
 \alias{etox_targets}
 \title{Get Quality Targets from a ETOX ID}
 \usage{
-etox_targets(id, verbose = TRUE)
+etox_targets(id, verbose = getOption("verbose"))
 }
 \arguments{
 \item{id}{character; ETOX ID}

--- a/man/etox_tests.Rd
+++ b/man/etox_tests.Rd
@@ -4,7 +4,7 @@
 \alias{etox_tests}
 \title{Get Tests from a ETOX ID}
 \usage{
-etox_tests(id, verbose = TRUE)
+etox_tests(id, verbose = getOption("verbose"))
 }
 \arguments{
 \item{id}{character; ETOX ID}

--- a/man/fn_percept.Rd
+++ b/man/fn_percept.Rd
@@ -4,7 +4,7 @@
 \alias{fn_percept}
 \title{Retrieve flavor percepts from www.flavornet.org}
 \usage{
-fn_percept(query, from = "cas", verbose = TRUE, CAS, ...)
+fn_percept(query, from = "cas", verbose = getOption("verbose"), CAS, ...)
 }
 \arguments{
 \item{query}{character; CAS number to search by. See \code{\link{is.cas}} for correct formatting}

--- a/man/get_chebiid.Rd
+++ b/man/get_chebiid.Rd
@@ -12,7 +12,7 @@ get_chebiid(
   match = c("all", "best", "first", "ask", "na"),
   max_res = 200,
   stars = c("all", "two only", "three only"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   ...
 )
 }

--- a/man/get_cid.Rd
+++ b/man/get_cid.Rd
@@ -9,7 +9,7 @@ get_cid(
   from = "name",
   domain = c("compound", "substance", "assay"),
   match = c("all", "first", "ask", "na"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   arg = NULL,
   first = NULL,
   ...

--- a/man/get_etoxid.Rd
+++ b/man/get_etoxid.Rd
@@ -8,7 +8,7 @@ get_etoxid(
   query,
   from = c("name", "cas", "ec", "gsbl", "rtecs"),
   match = c("all", "best", "first", "ask", "na"),
-  verbose = TRUE
+  verbose = getOption("verbose")
 )
 }
 \arguments{

--- a/man/get_wdid.Rd
+++ b/man/get_wdid.Rd
@@ -7,7 +7,7 @@
 get_wdid(
   query,
   match = c("best", "first", "all", "ask", "na"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   language = "en"
 )
 }

--- a/man/is.cas.Rd
+++ b/man/is.cas.Rd
@@ -4,7 +4,7 @@
 \alias{is.cas}
 \title{Check if input is a valid CAS}
 \usage{
-is.cas(x, verbose = TRUE)
+is.cas(x, verbose = getOption("verbose"))
 }
 \arguments{
 \item{x}{character; input CAS}

--- a/man/is.inchikey.Rd
+++ b/man/is.inchikey.Rd
@@ -4,7 +4,11 @@
 \alias{is.inchikey}
 \title{Check if input is a valid inchikey}
 \usage{
-is.inchikey(x, type = c("format", "chemspider"), verbose = TRUE)
+is.inchikey(
+  x,
+  type = c("format", "chemspider"),
+  verbose = getOption("verbose")
+)
 }
 \arguments{
 \item{x}{character; input InChIKey}

--- a/man/is.inchikey_cs.Rd
+++ b/man/is.inchikey_cs.Rd
@@ -4,7 +4,7 @@
 \alias{is.inchikey_cs}
 \title{Check if input is a valid inchikey using ChemSpider API}
 \usage{
-is.inchikey_cs(x, verbose = TRUE)
+is.inchikey_cs(x, verbose = getOption("verbose"))
 }
 \arguments{
 \item{x}{character; input string}

--- a/man/is.inchikey_format.Rd
+++ b/man/is.inchikey_format.Rd
@@ -4,7 +4,7 @@
 \alias{is.inchikey_format}
 \title{Check if input is a valid inchikey using format}
 \usage{
-is.inchikey_format(x, verbose = TRUE)
+is.inchikey_format(x, verbose = getOption("verbose"))
 }
 \arguments{
 \item{x}{character; input string}

--- a/man/is.smiles.Rd
+++ b/man/is.smiles.Rd
@@ -4,7 +4,7 @@
 \alias{is.smiles}
 \title{Check if input is a SMILES string}
 \usage{
-is.smiles(x, verbose = TRUE)
+is.smiles(x, verbose = getOption("verbose"))
 }
 \arguments{
 \item{x}{character; input SMILES.}

--- a/man/nist_ri.Rd
+++ b/man/nist_ri.Rd
@@ -11,7 +11,7 @@ nist_ri(
   polarity = c("polar", "non-polar"),
   temp_prog = c("isothermal", "ramp", "custom"),
   cas = NULL,
-  verbose = TRUE
+  verbose = getOption("verbose")
 )
 }
 \arguments{

--- a/man/opsin_query.Rd
+++ b/man/opsin_query.Rd
@@ -4,7 +4,7 @@
 \alias{opsin_query}
 \title{OPSIN web interface}
 \usage{
-opsin_query(query, verbose = TRUE, ...)
+opsin_query(query, verbose = getOption("verbose"), ...)
 }
 \arguments{
 \item{query}{character;  chemical name that should be queryed.}

--- a/man/pc_prop.Rd
+++ b/man/pc_prop.Rd
@@ -4,7 +4,7 @@
 \alias{pc_prop}
 \title{Retrieve compound properties from a pubchem CID}
 \usage{
-pc_prop(cid, properties = NULL, verbose = TRUE, ...)
+pc_prop(cid, properties = NULL, verbose = getOption("verbose"), ...)
 }
 \arguments{
 \item{cid}{character; Pubchem ID (CID).}

--- a/man/pc_sect.Rd
+++ b/man/pc_sect.Rd
@@ -8,7 +8,7 @@ pc_sect(
   id,
   section,
   domain = c("compound", "substance", "assay", "gene", "protein", "patent"),
-  verbose = TRUE
+  verbose = getOption("verbose")
 )
 }
 \arguments{

--- a/man/pc_synonyms.Rd
+++ b/man/pc_synonyms.Rd
@@ -8,7 +8,7 @@ pc_synonyms(
   query,
   from = c("name", "cid", "sid", "aid", "smiles", "inchi", "inchikey"),
   match = c("all", "first", "ask", "na"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   arg = NULL,
   choices = NULL,
   ...

--- a/man/srs_query.Rd
+++ b/man/srs_query.Rd
@@ -7,7 +7,7 @@
 srs_query(
   query,
   from = c("itn", "cas", "epaid", "tsn", "name"),
-  verbose = TRUE,
+  verbose = getOption("verbose"),
   ...
 )
 }

--- a/man/wd_ident.Rd
+++ b/man/wd_ident.Rd
@@ -4,7 +4,7 @@
 \alias{wd_ident}
 \title{Retrieve identifiers from Wikidata}
 \usage{
-wd_ident(id, verbose = TRUE)
+wd_ident(id, verbose = getOption("verbose"))
 }
 \arguments{
 \item{id}{character; identifier, as returned by \code{\link{get_wdid}}}

--- a/man/with_cts.Rd
+++ b/man/with_cts.Rd
@@ -4,7 +4,7 @@
 \alias{with_cts}
 \title{Auto-translate identifiers and search databases}
 \usage{
-with_cts(query, from, .f, .verbose = TRUE, ...)
+with_cts(query, from, .f, .verbose = getOption("verbose"), ...)
 }
 \arguments{
 \item{query}{character; the search term}

--- a/tests/testthat/test-alanwood.R
+++ b/tests/testthat/test-alanwood.R
@@ -7,7 +7,7 @@ test_that("examples in the article are unchanged", {
   aw_data <- aw_query(lc50$cas[1:3], from = "cas")
   igroup <- sapply(aw_data, function(y) y$subactivity[1])
 
-  expect_is(igroup, "character")
+  expect_type(igroup, "character")
   expect_equal(names(igroup), c("50-29-3", "52-68-6", "55-38-9"))
   expect_equal(unname(igroup), c("organochlorine insecticides",
                                  "phosphonate insecticides",
@@ -40,7 +40,7 @@ test_that("alanwood, invalid input", {
 
   comps <- c("balloon", NA)
   o1 <- aw_query(comps)
-  expect_is(o1, "list")
+  expect_type(o1, "list")
   expect_equal(o1[[1]], NA)
   expect_equal(o1[[2]], NA)
 })
@@ -49,7 +49,7 @@ test_that("alanwood, build_index", {
   skip_on_cran()
   skip_if_not(up, "Alanwood service is down")
 
-  idx <- suppressWarnings(build_aw_idx(verbose = FALSE, force_build = TRUE))
+  idx <- suppressWarnings(build_aw_idx(force_build = TRUE))
   expect_s3_class(idx, "data.frame")
   expect_equal(ncol(idx), 4)
   expect_equal(names(idx), c("names", "links", "linknames", "source"))

--- a/tests/testthat/test-chebi.R
+++ b/tests/testthat/test-chebi.R
@@ -33,10 +33,10 @@ test_that("chebi returns correct results", {
   A <- chebi_comp_entity("CHEBI:27744")
   B <- chebi_comp_entity("27732")
 
-  expect_is(a, "data.frame")
-  expect_is(b, "data.frame")
-  expect_is(A, "list")
-  expect_is(B, "list")
+  expect_s3_class(a, "data.frame")
+  expect_s3_class(b, "data.frame")
+  expect_type(A, "list")
+  expect_type(B, "list")
 
   expect_equal(names(a)[2], "chebiid")
   expect_length(names(a), 5)

--- a/tests/testthat/test-chemid.R
+++ b/tests/testthat/test-chemid.R
@@ -8,8 +8,9 @@ test_that("chemid returns correct results", {
   expect_type(o2, 'list')
   expect_type(o3, 'list')
 
-  o1 <- ci_query(c('xxxxx', NA, 'Aspirin', 'Triclosan'), from = 'name', match = 'best')
-  expect_is(o1, 'list')
+  o1 <- suppressWarnings(ci_query(c('xxxxx', NA, 'Aspirin', 'Triclosan'),
+                                  from = 'name', match = 'best'))
+  expect_type(o1, 'list')
 
   expect_true(length(o1) == 4)
   expect_true(is.na(o1[[1]]))
@@ -19,13 +20,13 @@ test_that("chemid returns correct results", {
   expect_length(o1[[3]], 9)
   expect_s3_class(o1[[3]]$physprop, "data.frame")
 
-  b1 <- ci_query('Tetracyclin', from = 'name')
+  b1 <- suppressWarnings(ci_query('Tetracyclin', from = 'name'))
   expect_equal(b1[[1]]$name[1], "Tetracycline")
-  b2 <- ci_query('Edetic acid', from = 'name', match = 'best')
+  b2 <- suppressWarnings(ci_query('Edetic acid', from = 'name', match = 'best'))
   expect_equal(b2[[1]]$name[1], "Edetic acid")
 
   # test multiple matches
-  m1 <- ci_query('Tetracyclin', from = 'name', match = 'first')
+  m1 <- suppressWarnings(ci_query('Tetracyclin', from = 'name', match = 'first'))
   m2 <- b1 #best is default
   m3 <- ci_query('Tetracyclin', from = 'name', match = 'na')
 

--- a/tests/testthat/test-cir.R
+++ b/tests/testthat/test-cir.R
@@ -3,17 +3,16 @@ test_that("cir_query()", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
 
-  expect_equal(cir_query('Triclosan', 'mw', verbose = FALSE)[[1]], 289.5451)
-  expect_equal(cir_query('xxxxxxx', 'mw', verbose = FALSE)[[1]], NA)
-  expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number', verbose = FALSE)[[1]],
+  expect_equal(cir_query('Triclosan', 'mw')[[1]], 289.5451)
+  expect_equal(cir_query('xxxxxxx', 'mw')[[1]], NA)
+  expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number')[[1]],
             "InChIKey=XEFQLINVKFYRCS-UHFFFAOYSA-N")
-  expect_true(length(cir_query('Triclosan', 'cas', verbose = FALSE)[[1]]) > 1)
-  expect_message(cir_query("acetic acid", "mw", match = "first"))
-  expect_length(cir_query('Triclosan', 'cas', match = "first", verbose = FALSE)[[1]], 1)
-  expect_length(cir_query(c('Triclosan', 'Aspirin'), 'cas', verbose = FALSE), 2)
+  expect_true(length(cir_query('Triclosan', 'cas')[[1]]) > 1)
+  expect_length(cir_query('Triclosan', 'cas', match = "first")[[1]], 1)
+  expect_length(cir_query(c('Triclosan', 'Aspirin'), 'cas'), 2)
 
-  # skip("I have no clue why this one fails on R CMD check.  It works when run in the console!")
-  expect_equivalent(cir_query('acetic acid', 'mw', match = "first"), c(`acetic acid` = 60.0524))
+  expect_equal(cir_query('acetic acid', 'mw', match = "first"),
+               list(`acetic acid` = 60.0524))
 
 })
 

--- a/tests/testthat/test-cts.R
+++ b/tests/testthat/test-cts.R
@@ -6,9 +6,10 @@ test_that("cts_compinfo()", {
 
   expect_true(is.na(cts_compinfo("xxx")))
 
-  o1 <- suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-N", verbose = FALSE))
-  o2 <- suppressWarnings(cts_compinfo(c("XEFQLINVKFYRCS-UHFFFAOYSA-N", "XEFQLINVKFYRCS-UHFFFAOYSA-X"), verbose = FALSE))
-  expect_equal(suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-X", verbose = FALSE))[[1]], NA)
+  o1 <- suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-N"))
+  o2 <- suppressWarnings(cts_compinfo(c("XEFQLINVKFYRCS-UHFFFAOYSA-N",
+                                        "XEFQLINVKFYRCS-UHFFFAOYSA-X")))
+  expect_equal(suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-X"))[[1]], NA)
   expect_true(is.na(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-X")))
   expect_length(o1[[1]], 10)
   expect_equal(round(o1[[1]][["molweight"]], 3), 289.542)
@@ -25,11 +26,12 @@ test_that("cts_convert()", {
   expect_error(cts_convert(comp, c('Chemical Name', 'CAS'), 'CAS'))
   expect_error(cts_convert('Triclosan', 'CAS'))
   expect_true(is.na(cts_convert('xxxx', 'Chemical Name', 'inchikey')))
-  o1 <- cts_convert(comp, 'Chemical Name', 'inchikey', match = "first", verbose = FALSE)
+  o1 <- cts_convert(comp, 'Chemical Name', 'inchikey', match = "first")
   expect_length(o1, 2)
 
   expect_equal(o1[[1]], 'XEFQLINVKFYRCS-UHFFFAOYSA-N')
-  expect_equivalent(cts_convert(NA, from = "Chemical Name", to = "inchikey"), NA)
+  expect_equal(cts_convert(NA, from = "Chemical Name", to = "inchikey"),
+               list(NA), ignore_attr = TRUE)
 })
 
 

--- a/tests/testthat/test-etox.R
+++ b/tests/testthat/test-etox.R
@@ -20,10 +20,11 @@ test_that("examples in the article are unchanged", {
     }
   }))
 
-  expect_is(ids, "data.frame")
+  expect_s3_class(ids, "data.frame")
   expect_equal(names(ids), c("query", "match", "etoxid"))
-  expect_equivalent(ids$etoxid,
-               c("8668", "8494", NA, "8397", "7240", "7331"))
+  expect_equal(ids$etoxid,
+               c("8668", "8494", NA, "8397", "7240", "7331"),
+               ignore_attr = TRUE)
   expect_equal(
     ids$match,
     c("2,4-Xylenol", "4-Chlor-2-methylphenol", NA,
@@ -32,7 +33,7 @@ test_that("examples in the article are unchanged", {
                c("2,4-Dimethylphenol", "4-Chlor-2-methylphenol",
                  "4-para-nonylphenol", "Atrazin", "Benzol", "Desethylatrazin"))
 
-  expect_is(etox_cas, "character")
+  expect_type(etox_cas, "character")
   expect_equal(names(etox_cas),
                c("8668", "8494", NA, "8397", "7240", "7331"))
   expect_equal(unname(etox_cas),c("105-67-9", "1570-64-5", NA, "1912-24-9",
@@ -65,8 +66,9 @@ test_that("get_etoxid returns correct results", {
   expect_s3_class(o7, "data.frame")
   expect_s3_class(do2, "data.frame")
 
-  expect_equivalent(o1$etoxid, c("20179", "7419"))
-  expect_equivalent(o2$etoxid, c("89236", "20179", "7419", "9051"))
+  expect_equal(o1$etoxid, c("20179", "7419"), ignore_attr = TRUE)
+  expect_equal(o2$etoxid, c("89236", "20179", "7419", "9051"),
+               ignore_attr = TRUE)
 })
 
 test_that("examples from webchem article run", {
@@ -78,23 +80,24 @@ test_that("examples from webchem article run", {
   ids <- get_etoxid(head(unique(jagst$substance),6), match = "best")
 
   expect_s3_class(ids, "data.frame")
-  expect_equivalent(ids$etoxid, c("8668","8494",NA,"8397","7240","7331"))
-  expect_equivalent(ids$match, c(
+  expect_equal(ids$etoxid, c("8668","8494",NA,"8397","7240","7331"),
+               ignore_attr = TRUE)
+  expect_equal(ids$match, c(
     "2,4-Xylenol",
     "4-Chlor-2-methylphenol",
     NA,
     "Atrazin",
     "Benzol",
     "Desethylatrazin"
-  ))
-  expect_equivalent(ids$query, c(
+  ), ignore_attr = TRUE)
+  expect_equal(ids$query, c(
     "2,4-Dimethylphenol",
     "4-Chlor-2-methylphenol",
     "4-para-nonylphenol",
     "Atrazin",
     "Benzol",
     "Desethylatrazin"
-  ))
+  ), ignore_attr = TRUE)
 
 })
 

--- a/tests/testthat/test-extractors.R
+++ b/tests/testthat/test-extractors.R
@@ -4,7 +4,7 @@ test_that("extractors work with etox", {
   skip_if_not(ping_service("etox"), "ETOX service is down")
 
   out_etox_basic <- etox_basic(8252)
-  expect_equivalent(cas(out_etox_basic), "50-00-0")
+  expect_equal(cas(out_etox_basic), "50-00-0", ignore_attr = TRUE)
   expect_error(inchikey(out_etox_basic))
   expect_error(smiles(out_etox_basic))
 })
@@ -13,11 +13,14 @@ test_that("extractors work with chemid", {
   skip_on_cran()
   skip_if_not(ping_service("ci"), "CHEMID service is down")
 
-  out_ci_query <- ci_query(c('Aspirin', 'Triclosan'), from = 'name')
-  expect_equivalent(cas(out_ci_query),  c("50-78-2", "3380-34-5"))
-  expect_equivalent(inchikey(out_ci_query),
-                    c("BSYNRYMUTXBXSQ-UHFFFAOYSA-N", "XEFQLINVKFYRCS-UHFFFAOYSA-N"))
-  expect_equivalent(smiles(out_ci_query), c("CC(=O)", "Oc1cc(Cl)"))
+  out_ci_query <- suppressWarnings(ci_query(c('Aspirin', 'Triclosan'),
+                                            from = 'name'))
+  expect_equal(cas(out_ci_query),  c("50-78-2", "3380-34-5"), ignore_attr = TRUE)
+  expect_equal(inchikey(out_ci_query),
+                    c("BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+                      "XEFQLINVKFYRCS-UHFFFAOYSA-N"), ignore_attr = TRUE)
+  expect_equal(smiles(out_ci_query), c("CC(=O)", "Oc1cc(Cl)"),
+               ignore_attr = TRUE)
 })
 
 test_that("extractors work with opsin", {
@@ -26,9 +29,11 @@ test_that("extractors work with opsin", {
 
   out_opsin_query <- opsin_query(c('Cyclopropane', 'Octane'))
   expect_error(cas(out_opsin_query), "CAS is not returned by this datasource!")
-  expect_equivalent(inchikey(out_opsin_query),
-                    c("LVZWSLJZHVFIQJ-UHFFFAOYSA-N", "TVMXDCGIABBOFY-UHFFFAOYSA-N"))
-  expect_equivalent(smiles(out_opsin_query), c("C1CC1", "CCCCCCCC"))
+  expect_equal(inchikey(out_opsin_query),
+                    c("LVZWSLJZHVFIQJ-UHFFFAOYSA-N",
+                      "TVMXDCGIABBOFY-UHFFFAOYSA-N"), ignore_attr = TRUE)
+  expect_equal(smiles(out_opsin_query), c("C1CC1", "CCCCCCCC"),
+               ignore_attr = TRUE)
 })
 
 test_that("extractors work with Alanwood", {
@@ -36,9 +41,11 @@ test_that("extractors work with Alanwood", {
   skip_if_not(ping_service("aw"), "Alanwood database not reachable")
 
   out_aw_query <- aw_query(c('Fluazinam', 'Diclofop'), from = 'name')
-  expect_equivalent(cas(out_aw_query), c("79622-59-6", "40843-25-2"))
-  expect_equivalent(inchikey(out_aw_query),
-                    c("UZCGKGPEKUCDTF-UHFFFAOYSA-N", "OOLBCHYXZDXLDS-UHFFFAOYSA-N"))
+  expect_equal(cas(out_aw_query), c("79622-59-6", "40843-25-2"),
+               ignore_attr = TRUE)
+  expect_equal(inchikey(out_aw_query),
+                    c("UZCGKGPEKUCDTF-UHFFFAOYSA-N",
+                      "OOLBCHYXZDXLDS-UHFFFAOYSA-N"), ignore_attr = TRUE)
   expect_error(smiles(out_aw_query), "SMILES is not returned by this datasource!")
 
 })
@@ -49,11 +56,13 @@ test_that("extractors work with Wikidata", {
 
   id <- c("Q408646", "Q18216")
   out_wd_ident <- wd_ident(id)
-  expect_equivalent(cas(out_wd_ident), c("3380-34-5", "50-78-2"))
-  expect_equivalent(inchikey(out_wd_ident),
-                    c("XEFQLINVKFYRCS-UHFFFAOYSA-N", "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"))
-  expect_equivalent(smiles(out_wd_ident),
-                    c("C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl","CC(=O)OC1=CC=CC=C1C(=O)O"))
+  expect_equal(cas(out_wd_ident), c("3380-34-5", "50-78-2"), ignore_attr = TRUE)
+  expect_equal(inchikey(out_wd_ident),
+                    c("XEFQLINVKFYRCS-UHFFFAOYSA-N",
+                      "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"), ignore_attr = TRUE)
+  expect_equal(smiles(out_wd_ident),
+                    c("C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl",
+                      "CC(=O)OC1=CC=CC=C1C(=O)O"), ignore_attr = TRUE)
 })
 
 test_that("extractors work with pubchem", {
@@ -61,13 +70,16 @@ test_that("extractors work with pubchem", {
   skip_if_not(ping_service("pc"), "Pubchem service is down")
 
   out_pc_prop <- pc_prop(c(5564, 2244))
-  out_pc_prop2 <- pc_prop(5564, properties = c('MolecularFormula', 'MolecularWeight'))
+  out_pc_prop2 <- pc_prop(5564, properties = c('MolecularFormula',
+                                               'MolecularWeight'))
   expect_error(cas(out_pc_prop))
-  expect_equivalent(inchikey(out_pc_prop),
-                    c("XEFQLINVKFYRCS-UHFFFAOYSA-N", "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"))
+  expect_equal(inchikey(out_pc_prop),
+                    c("XEFQLINVKFYRCS-UHFFFAOYSA-N",
+                      "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"), ignore_attr = TRUE)
   expect_error(inchikey(out_pc_prop2))
-  expect_equivalent(smiles(out_pc_prop),
-                    c("C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl", "CC(=O)OC1=CC=CC=C1C(=O)O"))
+  expect_equal(smiles(out_pc_prop),
+                    c("C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl",
+                      "CC(=O)OC1=CC=CC=C1C(=O)O"), ignore_attr = TRUE)
   expect_error(smiles(out_pc_prop2))
 })
 
@@ -77,7 +89,8 @@ test_that("extractors work with PAN", {
   skip_if_not(ping_service("pan"), "PAN service is down")
 
   out_pan_query <- pan_query(c('2,4-dichlorophenol', 'Atrazin'), match = 'best')
-  expect_equivalent(cas(out_pan_query),  c("120-83-2", "1912-24-9"))
+  expect_equal(cas(out_pan_query),  c("120-83-2", "1912-24-9"),
+               ignore_attr = TRUE)
   expect_error(inchikey(out_pan_query))
   expect_error(smiles(out_pan_query))
 })

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -15,7 +15,7 @@ test_that("with_cts() works when no translation needed", {
       query = CASs,
       from = "cas",
       .f = "fn_percept",
-      .verbose = TRUE
+      .verbose = getOption("verbose")
     )
   b <- fn_percept(CASs)
   expect_equal(a, b)
@@ -46,5 +46,5 @@ test_that("find_db() function works", {
   df <- tibble(query = c("triclosan", NA, "balloon"),
                etox = c(TRUE, FALSE, FALSE),
                fn = c(FALSE, FALSE, FALSE))
-  expect_equivalent(out, df)
+  expect_equal(out, df, ignore_attr = TRUE)
 })

--- a/tests/testthat/test-nist.R
+++ b/tests/testthat/test-nist.R
@@ -94,7 +94,8 @@ test_that("nist_ri() works with multiple queries", {
       polarity = "non-polar",
       temp_prog = "ramp"
     )
-  expect_equivalent(unique(myRIs$query), c("78-70-6", "13474-59-4"))
+  expect_equal(unique(myRIs$query), c("78-70-6", "13474-59-4"),
+               ignore_attr = TRUE)
 })
 
 test_that("cas =  is deprecated gently", {
@@ -126,5 +127,5 @@ test_that("nist_ri works with NAs", {
     colnames(natest),
     colnames(test)
   )
-  expect_equivalent(unique(natest$query), c(NA, "107-86-8"))
+  expect_equal(unique(natest$query), c(NA, "107-86-8"), ignore_attr = TRUE)
 })

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -63,8 +63,8 @@ test_that("get_cid()", {
   expect_true(nrow(get_cid(c("Triclosan", "Aspirin"))) == 2)
   #invalid input
   expect_true(is.na(get_cid(NA)$cid[1]))
-  expect_true(is.na(suppressWarnings(get_cid("xxxx", verbose = FALSE))$cid[1]))
-  expect_equal(capture_messages(get_cid("balloon")),
+  expect_true(is.na(suppressWarnings(get_cid("xxxx"))$cid[1]))
+  expect_equal(capture_messages(get_cid("balloon", verbose = TRUE)),
                c("Querying balloon. ", "Not Found (HTTP 404).", "\n"))
   # sourceall
   expect_equal(get_cid("Optopharma Ltd", from = "sourceall",
@@ -82,10 +82,8 @@ test_that("pc_prop", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
 
-  b <- suppressWarnings(pc_prop("xxx", properties = "CanonicalSmiles",
-                                verbose = FALSE))
-  c <- pc_prop("5564", properties = c("CanonicalSmiles", "InChiKey"),
-               verbose = FALSE)
+  b <- suppressWarnings(pc_prop("xxx", properties = "CanonicalSmiles"))
+  c <- pc_prop("5564", properties = c("CanonicalSmiles", "InChiKey"))
   expect_true(is.na(b))
   expect_equal(ncol(c), 3)
 })
@@ -93,7 +91,7 @@ test_that("pc_prop", {
 test_that("pc_synonyms", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
-  expect_equivalent(pc_synonyms(NA), NA)
+  expect_equal(pc_synonyms(NA), list(NA), ignore_attr = TRUE)
   expect_equal(pc_synonyms("Acetyl Salicylic Acid")[[1]][1], "aspirin")
   expect_equal(length(pc_synonyms(c("Triclosan", "Aspirin"))), 2)
   expect_equal(pc_synonyms("BPGDAMSIGCZZLK-UHFFFAOYSA-N",
@@ -108,8 +106,8 @@ test_that("cid integration tests", {
   expect_equal(pc_prop(get_cid("Triclosan")$cid[1],
                        properties = "CanonicalSmiles")$CanonicalSMILES,
                "C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl")
-  expect_true(is.na(suppressWarnings(pc_prop(NA, properties = "CanonicalSmiles",
-                            verbose = FALSE))))
+  expect_true(is.na(suppressWarnings(pc_prop(NA,
+                                             properties = "CanonicalSmiles"))))
 })
 
 test_that("pc_page()", {
@@ -120,27 +118,11 @@ test_that("pc_page()", {
 
   expect_type(a, "list")
   expect_length(a, 5)
-  expect_is(a[[1]], c("Node", "R6"))
-  expect_is(a[[2]], c("Node", "R6"))
+  expect_s3_class(a[[1]], c("Node", "R6"))
+  expect_s3_class(a[[2]], c("Node", "R6"))
   expect_equal(a[[3]], NA)
   expect_equal(a[[4]], NA)
   expect_equal(a[[5]], NA)
-})
-
-test_that("pc_extract() chemical and physical properties", {
-  skip_on_cran()
-  skip_if_not(up, "PubChem service is down")
-
-  s <- pc_page(c(NA, 176, 311, "balloon"), "chemical and physical properties")
-  mw <- pc_extract(s, "molecular weight") # example for a computed property
-  pd <- pc_extract(s, "physical description") # textual description
-  bp <- pc_extract(s, "boiling point")
-  mp <- pc_extract(s, "melting point")
-  fp <- pc_extract(s, "flash point")
-  so <- pc_extract(s, "solubility") # data with headers
-  ow <- pc_extract(s, "octanol/water partition coefficient") #negative numbers
-  logs <- pc_extract(s, "logs")
-  logkoa <- pc_extract(s, "logkoa")
 })
 
 test_that("pc_sect()", {
@@ -156,8 +138,8 @@ test_that("pc_sect()", {
   b <- pc_sect(2231, "depositor-supplied synonyms", "substance")
   expect_s3_class(b, c("tbl_df", "tbl", "data.frame"))
   expect_equal(names(b), c("SID", "Name", "Result", "SourceName", "SourceID"))
-  expect_equivalent(b$Result, c("cholesterol", "57-88-5",
-                                "5-cholestene-3beta-ol"))
+  expect_equal(b$Result, c("cholesterol", "57-88-5",
+                                "5-cholestene-3beta-ol"), ignore_attr = TRUE)
 
   c <- pc_sect(780286, "modify date", "assay")
   expect_s3_class(c, c("tbl_df", "tbl", "data.frame"))
@@ -167,6 +149,6 @@ test_that("pc_sect()", {
   d <- pc_sect("1ZHY_A", "Sequence", "protein")
   expect_s3_class(d, c("tbl_df", "tbl", "data.frame"))
   expect_equal(names(d), c("pdbID", "Name", "Result", "SourceName", "SourceID"))
-  expect_equivalent(d$Result[1],
-                    ">pdb|1ZHY|A Chain A, 1 Kes1 Protein (Run BLAST)")
+  expect_equal(d$Result[1], ">pdb|1ZHY|A Chain A, 1 Kes1 Protein (Run BLAST)",
+               ignore_attr = TRUE)
  })

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -67,8 +67,8 @@ test_that("get_cid()", {
   expect_equal(capture_messages(get_cid("balloon", verbose = TRUE)),
                c("Querying balloon. ", "Not Found (HTTP 404).", "\n"))
   # sourceall
-  expect_equal(get_cid("Optopharma Ltd", from = "sourceall",
-                       domain = "substance")$cid[1], "102361739")
+  opto <- get_cid("Optopharma Ltd", from = "sourceall", domain = "substance")
+  expect_equal(min(opto$cid), "102361739")
 })
 
 test_that("get_cid() handles special characters in SMILES", {

--- a/tests/testthat/test-srs.R
+++ b/tests/testthat/test-srs.R
@@ -12,8 +12,8 @@ test_that("SRS returns correct results", {
 
   expect_true(is.na(a))
   expect_true(is.na(b))
-  expect_is(c, "list")
-  expect_is(c$`50-00-0`, "data.frame")
+  expect_type(c, "list")
+  expect_s3_class(c$`50-00-0`, "data.frame")
   expect_equal(c$`50-00-0`$systematicName, "Formaldehyde")
 
   expect_equal(d$aniline$systematicName, "Benzenamine")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,13 +1,17 @@
-library(rcdk)
-
 up <- ping_service("cs_web")
 test_that("examples in the article are unchanged", {
   expect_false(is.inchikey("BQJCRHHNABKAKU-KBQPJGBKS-AN"))
-  expect_equal(capture_messages(is.inchikey("BQJCRHHNABKAKU-KBQPJGBKS-AN")),
+  # The default value for verbose has changed and it now requires verbose = TRUE
+  # to be added to the call to return the same output as the article example.
+  expect_equal(capture_messages(is.inchikey("BQJCRHHNABKAKU-KBQPJGBKS-AN",
+                                            verbose = TRUE)),
                "Hyphens not at position 15 and 26.\n")
   expect_false(is.cas('64-17-6'))
+  # The default value for verbose has changed and it now requires verbose = TRUE
+  # to be added to the call to return the same output as the article example.
   expect_equal(
-    capture_messages(is.cas("64-17-6")), "64-17-6: Checksum is not correct! 5 vs. 6\n")
+    capture_messages(is.cas("64-17-6", verbose = TRUE)),
+    "64-17-6: Checksum is not correct! 5 vs. 6\n")
   skip_if_not(up, "ChemSpider service is down, skipping tests")
   expect_false(is.inchikey("BQJCRHHNABKAKU-KBQPJGBKSA-5", type = "chemspider"))
 })
@@ -61,7 +65,8 @@ test_that("is.inchikey() returns correct results", {
 
 test_that("is.smiles() returns correct results", {
   expect_true(is.smiles('Clc1ccc(cc1)C(c2ccc(Cl)cc2)C(Cl)(Cl)Cl'))
-  expect_false(is.smiles('Clc1ccc(cc1)C(c2ccc(Cl)cc2)C(Cl)(Cl)ClWWX'))
+  expect_false(suppressWarnings(
+    is.smiles('Clc1ccc(cc1)C(c2ccc(Cl)cc2)C(Cl)(Cl)ClWWX')))
   expect_error(is.smiles(c('Clc1ccc(cc1)C(c2ccc(Cl)cc2)C(Cl)(Cl)Cl',
                            'Clc1ccc(cc1)C(c2ccc(Cl)cc2)C(Cl)(Cl)Cl')))
 })
@@ -75,10 +80,10 @@ test_that("extr_num() returns correct results", {
 
 test_that("as.cas() returns correct reults", {
 
-  expect_equivalent(as.cas(58082), "58-08-2")
-  expect_equivalent(as.cas(123456789), NA)
-  expect_equivalent(as.cas(c(761659, 123456789, "hexenol")),
-                   c("761-65-9", NA, NA))
+  expect_equal(as.cas(58082), "58-08-2", ignore_attr = TRUE)
+  expect_equal(as.cas(123456789), NA,ignore_attr = TRUE)
+  expect_equal(as.cas(c(761659, 123456789, "hexenol")),
+                   c("761-65-9", NA, NA), ignore_attr = TRUE)
 })
 
 test_that("matcher() warns when 'best' is used with chemical names", {

--- a/tests/testthat/test-wikidata.R
+++ b/tests/testthat/test-wikidata.R
@@ -15,8 +15,9 @@ test_that("get_wdid returns correct results", {
   expect_s3_class(o3, 'data.frame')
   expect_s3_class(o4, 'data.frame')
 
-  expect_equivalent(o1$wdid, c("Q163648", "Q57731093", NA, 'Q47512'))
-  expect_equivalent(o2$wdid[1:2], c("Q163648", "Q949424"))
+  expect_equal(o1$wdid, c("Q163648", "Q57731093", NA, 'Q47512'),
+               ignore_attr = TRUE)
+  expect_equal(o2$wdid[1:2], c("Q163648", "Q949424"), ignore_attr = TRUE)
 })
 
 test_that("get_wdid() handles NAs", {
@@ -38,8 +39,10 @@ test_that("wd_ident returns correct results", {
   expect_true(is.na(o1$smiles[3]))
   expect_true(is.na(o1$smiles[4]))
   expect_equal(o1$cas[1], '50-29-3')
-  expect_equal(names(o1), c('smiles', 'cas', 'cid', 'einecs', 'csid', 'inchi', 'inchikey',
-                           'drugbank', 'zvg', 'chebi', 'chembl', 'unii', 'lipidmaps', 'swisslipids', 'source_url', 'query'))
+  expect_equal(names(o1), c('smiles', 'cas', 'cid', 'einecs', 'csid', 'inchi',
+                            'inchikey', 'drugbank', 'zvg', 'chebi', 'chembl',
+                            'unii', 'lipidmaps', 'swisslipids', 'source_url',
+                            'query'))
 })
 
 test_that("wd_ident returns correct results for two lipids", {
@@ -50,8 +53,10 @@ test_that("wd_ident returns correct results for two lipids", {
   o1 <- wd_ident(id)
   expect_s3_class(o1, 'data.frame')
   expect_equal(nrow(o1), 2)
-  expect_equal(names(o1), c('smiles', 'cas', 'cid', 'einecs', 'csid', 'inchi', 'inchikey',
-                           'drugbank', 'zvg', 'chebi', 'chembl', 'unii', 'lipidmaps', 'swisslipids', 'source_url', 'query'))
+  expect_equal(names(o1), c('smiles', 'cas', 'cid', 'einecs', 'csid', 'inchi',
+                            'inchikey', 'drugbank', 'zvg', 'chebi', 'chembl',
+                            'unii', 'lipidmaps', 'swisslipids', 'source_url',
+                            'query'))
   expect_equal(o1$swisslipids[1], 'SLM:000000510')
   expect_equal(o1$lipidmaps[2], 'LMPR0102010003')
 })


### PR DESCRIPTION
This PR activates testthat 3rd edition and parallel testing.

A couple of changes were required:

* verbose messages now default to the global options which can be set through `options()`.
* The new default for verbose messages is `FALSE` as verbose messages clutter the testing panel otherwise.
* Deprecated functions were fixed, in case of webchem, this involved instances of `expect_is()`, and `expect_equivalent()`.

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed