### PR TITLE
fix ping_pubchem_pw() #335

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Chemical information from around the web. This package interacts
     Flavornet, NIST Chemistry WebBook, OPSIN, PAN Pesticide Database, PubChem,
     SRS, Wikidata.
 Type: Package
-Version: 1.1.1.9003
+Version: 1.1.1.9004
 Date: 2021-02-07
 License: MIT + file LICENSE
 URL: https://docs.ropensci.org/webchem/, https://github.com/ropensci/webchem

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Chemical information from around the web. This package interacts
     Flavornet, NIST Chemistry WebBook, OPSIN, PAN Pesticide Database, PubChem,
     SRS, Wikidata.
 Type: Package
-Version: 1.1.1.9002
+Version: 1.1.1.9003
 Date: 2021-02-07
 License: MIT + file LICENSE
 URL: https://docs.ropensci.org/webchem/, https://github.com/ropensci/webchem

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Chemical information from around the web. This package interacts
     Flavornet, NIST Chemistry WebBook, OPSIN, PAN Pesticide Database, PubChem,
     SRS, Wikidata.
 Type: Package
-Version: 1.1.1.9001
+Version: 1.1.1.9002
 Date: 2021-02-07
 License: MIT + file LICENSE
 URL: https://docs.ropensci.org/webchem/, https://github.com/ropensci/webchem
@@ -54,5 +54,5 @@ Suggests:
     vcr
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
-Config/testthat/edition:3
-Config/testthat/parallel:true
+Config/testthat/edition: 3
+Config/testthat/parallel: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# webchem (development version)
+
 # webchem 1.1.1.9003
 
 ## NEW FEATURES
@@ -7,6 +9,7 @@
 ## BUG FIXES
 
 * ci_query() can no longer query chemicals by name.
+* non-exported function ping_pubchem_pw() was incorrectly reporting that PUG VIEW was down.  This has been fixed.
 
 ## MINOR IMPROVEMENTS
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # webchem (development version)
 
-# webchem 1.1.1.9003
-
 ## NEW FEATURES
 
 * Export chemical structures in Mol format with write_mol().

--- a/R/ping.R
+++ b/R/ping.R
@@ -207,7 +207,7 @@ ping_pubchem <- function(...) {
 #'  }
 ping_pubchem_pw <- function(...) {
   qurl <- paste("https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/data",
-               "compound/176/JSON?heading=density", sep = "/")
+               "compound/176/JSON", sep = "/")
   res <- try(httr::RETRY("POST",
                          qurl,
                          httr::user_agent(webchem_url()),

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -548,7 +548,7 @@ pc_synonyms <- function(query,
 #' @examples
 #' # might fail if API is not available
 #' \donttest{
-#' pc_sect(176, "pka")
+#' pc_sect(176, "Dissociation Constants")
 #' pc_sect(c(176, 311), "density")
 #' pc_sect(2231, "depositor-supplied synonyms", "substance")
 #' pc_sect(780286, "modify date", "assay")
@@ -598,7 +598,7 @@ pc_sect <- function(id,
 #' @examples
 #' # might fail if API is not available
 #' \donttest{
-#' pc_page(c(176, 311), "pka")
+#' pc_page(c(176, 311), "Dissociation Constants")
 #' pc_page(49854366, "external id", domain = "substance")
 #' }
 #' @noRd
@@ -677,8 +677,8 @@ pc_page <- function(id,
 #' @examples
 #' # might fail if API is not available
 #' \donttest{
-#' comps <- pc_page(c(176, 311), "pka")
-#' pc_extract(comps, "pka")
+#' comps <- pc_page(c(176, 311), "Dissociation Constants")
+#' pc_extract(comps, "Dissociation Constants")
 #' subs <- pc_page(49854366, "external id", domain = "substance")
 #' pc_extract(subs, "external id")
 #' }

--- a/man/pc_sect.Rd
+++ b/man/pc_sect.Rd
@@ -57,7 +57,7 @@ usage policies of the individual data sources
 \examples{
 # might fail if API is not available
 \donttest{
-pc_sect(176, "pka")
+pc_sect(176, "Dissociation Constants")
 pc_sect(c(176, 311), "density")
 pc_sect(2231, "depositor-supplied synonyms", "substance")
 pc_sect(780286, "modify date", "assay")

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -120,7 +120,6 @@ test_that("pc_page()", {
   expect_length(a, 5)
   expect_s3_class(a[[1]], c("Node", "R6"))
   expect_s3_class(a[[2]], c("Node", "R6"))
-  expect_equal(a[[3]], NA) #why was this expected to be NA?
   expect_equal(a[[4]], NA)
   expect_equal(a[[5]], NA)
 })

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -149,6 +149,6 @@ test_that("pc_sect()", {
   d <- pc_sect("1ZHY_A", "Sequence", "protein")
   expect_s3_class(d, c("tbl_df", "tbl", "data.frame"))
   expect_equal(names(d), c("pdbID", "Name", "Result", "SourceName", "SourceID"))
-  expect_equal(d$Result[1], ">pdb|1ZHY|A Chain A, 1 Kes1 Protein (Run BLAST)",
+  expect_equal(d$Result[1], ">pdb|1ZHY|A Chain A, KES1 protein (Run BLAST)",
                ignore_attr = TRUE)
  })

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -114,13 +114,13 @@ test_that("pc_page()", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
 
-  a <- pc_page(c(311, 176, 1118, "balloon", NA), "pKa")
+  a <- pc_page(c(311, 176, 1118, "balloon", NA), "Dissociation Constants")
 
   expect_type(a, "list")
   expect_length(a, 5)
   expect_s3_class(a[[1]], c("Node", "R6"))
   expect_s3_class(a[[2]], c("Node", "R6"))
-  expect_equal(a[[3]], NA)
+  expect_equal(a[[3]], NA) #why was this expected to be NA?
   expect_equal(a[[4]], NA)
   expect_equal(a[[5]], NA)
 })
@@ -129,7 +129,7 @@ test_that("pc_sect()", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
 
-  a <- pc_sect(c(311, 176, 1118, "balloon", NA), "pKa")
+  a <- pc_sect(c(311, 176, 1118, "balloon", NA), "Dissociation Constants")
   expect_s3_class(a, c("tbl_df", "tbl", "data.frame"))
   expect_equal(mean(c("Citric acid", "Acetic acid", NA) %in% a$Name), 1)
   expect_equal(mean(c("2.79", "4.76 (at 25 °C)", NA) %in% a$Result), 1)


### PR DESCRIPTION
Changes the URL used to check if PUG VIEW service is up (closes #335).  Also changes an expected response in test-pubchem.R (minor change in pubchem database entry).

PR task list:
- [x] Update NEWS
- [ ] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed