### PR TITLE
Fix url construction for smiles queries

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,4 @@ codemeta.json
 ^codemeta\.json$
 
 cran-comments.md
+^CRAN-RELEASE$

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# webchem 1.1.2.9001
+
+## BUG FIXES
+
+* get_cid() became more robust to smiles queries with special characters.
+
 # webchem 1.1.2
 
 ## NEW FEATURES

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -183,13 +183,21 @@ get_cid <-
                       "json",
                       sep = "/")
       } else {
-        qurl <- paste("https://pubchem.ncbi.nlm.nih.gov/rest/pug",
-                      domain,
-                      from,
-                      URLencode(as.character(query), reserved = TRUE),
-                      "cids",
-                      "json",
-                      sep = "/")
+        if (from == "smiles") {
+          qurl <- paste0("https://pubchem.ncbi.nlm.nih.gov/rest/pug/",
+                         domain, "/",
+                         from, "/",
+                         "cids/JSON?smiles=",
+                         URLencode(as.character(query), reserved = TRUE))
+        } else {
+          qurl <- paste("https://pubchem.ncbi.nlm.nih.gov/rest/pug",
+                        domain,
+                        from,
+                        URLencode(as.character(query), reserved = TRUE),
+                        "cids",
+                        "json",
+                        sep = "/")
+        }
       }
       if (!is.null(arg)) qurl <- paste0(qurl, "?", arg)
       webchem_sleep(type = 'API')

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -71,16 +71,19 @@ test_that("get_cid()", {
   expect_equal(min(opto$cid), "102361739")
 
   #issue 283
+  smiles0 <- "O=S(=O)(NCCNC/C=C/c1ccc(Br)cc1)c2cccc3cnccc23"
   smiles1 <- "FC(OC(C(F)(F)F)Cl)F"
   smiles2 <- "CC(C)([C@H]1/C=C(/C(F)(F)F)\\Cl)[C@@H]1C(OCC1=C(C)C(C2=CC=CC=C2)=CC=C1)=O"
   smiles3 <- "CCCOC/C(\\N1C=NC=C1)=N\\C(C(C(F)(F)F)=C1)=CC=C1Cl"
   smiles4 <- "FC(/C(\\C1=CC=CC=C1)=N\\C1=CC=CC=C1)(F)F"
 
+  cid0 <- get_cid(smiles0, from = "smiles", domain = "compound")
   cid1 <- get_cid(smiles1, from = "smiles", domain = "compound")
   cid2 <- get_cid(smiles2, from = "smiles", domain = "compound")
   cid3 <- get_cid(smiles3, from = "smiles", domain = "compound")
   cid4 <- get_cid(smiles4, from = "smiles", domain = "compound")
 
+  expect_equal(cid0$cid, "449241")
   expect_equal(cid1$cid, "3763")
   expect_equal(cid2$cid, "6442842")
   expect_equal(cid3$cid, "91699")

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -69,6 +69,22 @@ test_that("get_cid()", {
   # sourceall
   opto <- get_cid("Optopharma Ltd", from = "sourceall", domain = "substance")
   expect_equal(min(opto$cid), "102361739")
+
+  #issue 283
+  smiles1 <- "FC(OC(C(F)(F)F)Cl)F"
+  smiles2 <- "CC(C)([C@H]1/C=C(/C(F)(F)F)\\Cl)[C@@H]1C(OCC1=C(C)C(C2=CC=CC=C2)=CC=C1)=O"
+  smiles3 <- "CCCOC/C(\\N1C=NC=C1)=N\\C(C(C(F)(F)F)=C1)=CC=C1Cl"
+  smiles4 <- "FC(/C(\\C1=CC=CC=C1)=N\\C1=CC=CC=C1)(F)F"
+
+  cid1 <- get_cid(smiles1, from = "smiles", domain = "compound")
+  cid2 <- get_cid(smiles2, from = "smiles", domain = "compound")
+  cid3 <- get_cid(smiles3, from = "smiles", domain = "compound")
+  cid4 <- get_cid(smiles4, from = "smiles", domain = "compound")
+
+  expect_equal(cid1$cid, "3763")
+  expect_equal(cid2$cid, "6442842")
+  expect_equal(cid3$cid, "91699")
+  expect_equal(cid4$cid, "136176")
 })
 
 test_that("get_cid() handles special characters in SMILES", {


### PR DESCRIPTION
This PR is linked to Issue #283.

First I tried to update the original url constructor based on the url suggested within Issue #283, like so:

```
qurl <- paste0("https://pubchem.ncbi.nlm.nih.gov/rest/pug/",
                       domain, "/", 
                       from, "/", 
                       "cids/JSON?",
                       from, "=",
                       URLencode(as.character(query), reserved = TRUE))
```

Notice the small change: after `cids/JSON?` I substituted `smiles=` ,with `from, "="` to generalise. However, many of the tests broke. Therefore, I just added the suggested url constructor as a special case -> `from == "smiles"`. What do you think?



PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed