### PR TITLE
Change `cir_query()` output to tibble #289

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Chemical information from around the web. This package interacts
     Flavornet, NIST Chemistry WebBook, OPSIN, PAN Pesticide Database, PubChem,
     SRS, Wikidata.
 Type: Package
-Version: 1.1.2
+Version: 1.1.2.9002
 Date: 2021-12-06
 License: MIT + file LICENSE
 URL: https://docs.ropensci.org/webchem/, https://github.com/ropensci/webchem

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # webchem 1.1.2.9001
 
+## NEW FEATURES
+
+* cir_query() now returns a tibble instead of a list to be consistent with other translator functions. This is a potentially *breaking change* for users.
+
 ## BUG FIXES
 
 * get_cid() became more robust to smiles queries with special characters.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# webchem 1.1.2.9001
+# webchem (development version)
 
 ## NEW FEATURES
 

--- a/R/cir.R
+++ b/R/cir.R
@@ -131,11 +131,11 @@ cir_query <- function(identifier,
   }
 
   match <- match.arg(match)
-
+  na_tbl <- tibble(query = NA, !!representation := NA)
   foo <- function(identifier, representation, resolver, match, verbose) {
     if (is.na(identifier)) {
       if (verbose) webchem_message("na")
-      return(NA)
+      return(na_tbl)
     }
     if (verbose) webchem_message("query", identifier, appendLF = FALSE)
     identifier <- URLencode(identifier, reserved = TRUE)
@@ -152,7 +152,7 @@ cir_query <- function(identifier,
                          quiet = TRUE), silent = TRUE)
     if (inherits(h, "try-error")) {
       if (verbose) webchem_message("service_down")
-      return(NA)
+      return(na_tbl)
     }
     if (verbose) message(httr::message_for_status(h))
     if (h$status_code == 200){
@@ -160,7 +160,7 @@ cir_query <- function(identifier,
       out <- xml_text(xml_find_all(tt, '//item'))
       if (length(out) == 0) {
         if (verbose) webchem_message("not_found")
-        return(NA)
+        return(na_tbl)
       }
       out <- matcher(out, query = identifier, match = match, verbose = verbose)
       if (representation %in% c('mw', 'monoisotopic_mass', 'h_bond_donor_count',
@@ -171,11 +171,12 @@ cir_query <- function(identifier,
                                 'heavy_atom_count', 'deprotonable_group_count',
                                 'protonable_group_count') )
         out <- as.numeric(out)
+
       out_tbl <- tibble(query = identifier, !!representation := out)
       return(out_tbl)
     }
     else {
-      return(NA)
+      return(na_tbl)
     }
   }
 

--- a/R/cir.R
+++ b/R/cir.R
@@ -19,7 +19,7 @@
 #' @param choices deprecated.  Use the \code{match} argument instead.
 #' @param verbose logical; should a verbose output be printed on the console?
 #' @param ... currently not used.
-#' @return A list of character vectors.
+#' @return A tibble with a `query` column an a column for the requested representation.
 #' @details
 #'  CIR can resolve can be of the following \code{identifier}: Chemical Names,
 #'  IUPAC names,

--- a/R/cir.R
+++ b/R/cir.R
@@ -112,7 +112,8 @@
 #'
 #'}
 #' @export
-cir_query <- function(identifier, representation = "smiles",
+cir_query <- function(identifier,
+                      representation = "smiles",
                       resolver = NULL,
                       match = c("all", "first", "ask", "na"),
                       verbose = getOption("verbose"),
@@ -124,6 +125,11 @@ cir_query <- function(identifier, representation = "smiles",
   if (!missing("choices")) {
     stop("`choices` is deprecated.  Use `match` instead.")
   }
+
+  if (length(representation) > 1 | !is.character(representation)) {
+    stop("`representation` must be a string.  See ?cir_query for options.")
+  }
+
   match <- match.arg(match)
   foo <- function(identifier, representation, resolver, first, verbose) {
     if (is.na(identifier)) {

--- a/R/cir.R
+++ b/R/cir.R
@@ -138,9 +138,9 @@ cir_query <- function(identifier,
       return(na_tbl)
     }
     if (verbose) webchem_message("query", identifier, appendLF = FALSE)
-    identifier <- URLencode(identifier, reserved = TRUE)
+    id <- URLencode(identifier, reserved = TRUE)
     baseurl <- "https://cactus.nci.nih.gov/chemical/structure"
-    qurl <- paste(baseurl, identifier, representation, 'xml', sep = '/')
+    qurl <- paste(baseurl, id, representation, 'xml', sep = '/')
     if (!is.null(resolver)) {
       qurl <- paste0(qurl, '?resolver=', resolver)
     }

--- a/R/cir.R
+++ b/R/cir.R
@@ -131,7 +131,8 @@ cir_query <- function(identifier,
   }
 
   match <- match.arg(match)
-  foo <- function(identifier, representation, resolver, first, verbose) {
+
+  foo <- function(identifier, representation, resolver, match, verbose) {
     if (is.na(identifier)) {
       if (verbose) webchem_message("na")
       return(NA)
@@ -170,16 +171,18 @@ cir_query <- function(identifier,
                                 'heavy_atom_count', 'deprotonable_group_count',
                                 'protonable_group_count') )
         out <- as.numeric(out)
-      return(out)
+      out_tbl <- tibble(query = identifier, !!representation := out)
+      return(out_tbl)
     }
     else {
       return(NA)
     }
   }
+
+
   out <- lapply(identifier, foo, representation = representation,
-                resolver = resolver, first = first, verbose = verbose)
-  names(out) <- identifier
-  return(out)
+                resolver = resolver, match = match, verbose = verbose)
+  bind_rows(out)
 }
 
 #' Query Chemical Identifier Resolver Images

--- a/R/cir.R
+++ b/R/cir.R
@@ -20,7 +20,7 @@
 #' @param choices deprecated.  Use the \code{match} argument instead.
 #' @param verbose logical; should a verbose output be printed on the console?
 #' @param ... currently not used.
-#' @return A tibble with a `query` column an a column for the requested representation.
+#' @return A tibble with a `query` column and a column for the requested representation.
 #' @details
 #'  CIR can resolve can be of the following \code{identifier}: Chemical Names,
 #'  IUPAC names,

--- a/R/cir.R
+++ b/R/cir.R
@@ -5,6 +5,7 @@
 #'
 #' @import xml2
 #' @importFrom utils URLencode
+#' @importFrom rlang :=
 #'
 #' @param identifier character; chemical identifier.
 #' @param representation character; what representation of the identifier should

--- a/R/cir.R
+++ b/R/cir.R
@@ -132,8 +132,9 @@ cir_query <- function(identifier,
   }
 
   match <- match.arg(match)
-  na_tbl <- tibble(query = NA, !!representation := NA)
+
   foo <- function(identifier, representation, resolver, match, verbose) {
+    na_tbl <- tibble(query = identifier, !!representation := NA)
     if (is.na(identifier)) {
       if (verbose) webchem_message("na")
       return(na_tbl)

--- a/R/utils.R
+++ b/R/utils.R
@@ -502,7 +502,7 @@ matcher <-
         } else {
           choices <- x
         }
-        pick <- menu(choices, graphics = FALSE, "Select one:")
+        pick <- menu(choices, graphics = FALSE, paste0("Select result for '", query, "':"))
         return(x[pick])
 
       } else if (match == "na") {

--- a/man/cir_query.Rd
+++ b/man/cir_query.Rd
@@ -36,7 +36,7 @@ returns all matches, \code{"first"} returns only the first result,
 \item{...}{currently not used.}
 }
 \value{
-A list of character vectors.
+A tibble with a `query` column an a column for the requested representation.
 }
 \description{
 A interface to the Chemical Identifier Resolver (CIR).

--- a/tests/testthat/test-cir.R
+++ b/tests/testthat/test-cir.R
@@ -31,6 +31,17 @@ test_that("cir_query() handles special characters in SMILES", {
                "InChIKey=HSFWRNGVRCDJHI-UHFFFAOYNA-N")
 })
 
+test_that("cir_query() handles NA queries and queries that return NA", {
+  skip_on_cran()
+  skip_if_not(up, "CIR server is down")
+
+  expect_identical(
+    cir_query(c("Triclosan", "pumpkin", NA), representation = "cas",match = "first"),
+    tibble(query = c("Triclosan", "pumpkin", NA_character_),
+           cas = c("3380-34-5", NA_character_, NA_character_))
+  )
+})
+
 test_that("cir_img()", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")

--- a/tests/testthat/test-cir.R
+++ b/tests/testthat/test-cir.R
@@ -3,16 +3,16 @@ test_that("cir_query()", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
 
-  expect_equal(cir_query('Triclosan', 'mw')[[1]], 289.5451)
-  expect_equal(cir_query('xxxxxxx', 'mw')[[1]], NA)
-  expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number')[[1]],
+  expect_equal(cir_query('Triclosan', 'mw')$mw[1], 289.5451)
+  expect_equal(cir_query('xxxxxxx', 'mw')$mw[1], NA)
+  expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number')$stdinchikey[1],
             "InChIKey=XEFQLINVKFYRCS-UHFFFAOYSA-N")
-  expect_true(length(cir_query('Triclosan', 'cas')[[1]]) > 1)
-  expect_length(cir_query('Triclosan', 'cas', match = "first")[[1]], 1)
-  expect_length(cir_query(c('Triclosan', 'Aspirin'), 'cas'), 2)
+  expect_true(nrow(cir_query('Triclosan', 'cas')) > 1)
+  expect_true(nrow(cir_query('Triclosan', 'cas', match = "first")) == 1)
+  expect_true(nrow(cir_query(c('Triclosan', 'Aspirin'), 'cas', match = "first")) == 2)
 
   expect_equal(cir_query('acetic acid', 'mw', match = "first"),
-               list(`acetic acid` = 60.0524))
+               tibble(query = "acetic acid", mw = 60.0524))
 
 })
 
@@ -20,14 +20,14 @@ test_that("cir_query() doesn't mistake NA for sodium", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
 
-  expect_true(is.na(cir_query(as.character(NA), 'cas')))
+  expect_true(is.na(cir_query(as.character(NA), 'cas')$cas))
 })
 
 test_that("cir_query() handles special characters in SMILES", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
 
-  expect_equal(cir_query("C#C", representation = "inchikey")[[1]],
+  expect_equal(cir_query("C#C", representation = "inchikey")$inchikey,
                "InChIKey=HSFWRNGVRCDJHI-UHFFFAOYNA-N")
 })
 


### PR DESCRIPTION
This changes the output of `cir_query()` to a tibble, a potentially breaking change for some.  Suggested in #289.  I also made a small fix to the `matcher()` utility so the query is printed when match = "ask".


PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed