### PR TITLE
Update cts_convert to accept numeric input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## BUG FIXES
 
+* cts_convert() now accepts numeric input as well e.g. PubChem CID.
 * get_cid() became more robust to smiles queries with special characters.
 * `bcpc_query` now correctly parses the activity in cases that two activities are given (e.g. "herbicides" and "plant growth regulators")
 

--- a/R/cts.R
+++ b/R/cts.R
@@ -148,6 +148,7 @@ cts_convert <- function(query,
          argument for `from` and `to`.')
   }
 
+  query <- as.character(query)
   from <-  match.arg(tolower(from), c(cts_from(), "name"))
   to <-  match.arg(tolower(to), c(cts_to(), "name"))
   match <- match.arg(match)

--- a/tests/testthat/test-cts.R
+++ b/tests/testthat/test-cts.R
@@ -41,6 +41,9 @@ test_that("cts_convert()", {
   expect_equal(cts_convert(NA, from = "Chemical Name", to = "inchikey"),
                list(NA), ignore_attr = TRUE)
 
+  expect_equal(cts_convert(180, "pubchem cid", "inchikey")[[1]],
+               "CSCPPACGZOOCGX-UHFFFAOYSA-N")
+
 
 })
 


### PR DESCRIPTION
`cts_convert()` produced an error when the query was not a string. However, in certain cases, like with PubChem CIDs, numeric queries are perfectly valid. This PR suggests and edit to the `cts_convert()` function: queries are automatically converted to characters.

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if appropriate)
- [ ] Update documentation with `devtools::document()`
- [ ] Check package passed