### PR TITLE
Add sleep to ChemSpider functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Chemical information from around the web. This package interacts
     Flavornet, NIST Chemistry WebBook, OPSIN, PAN Pesticide Database, PubChem,
     SRS, Wikidata.
 Type: Package
-Version: 1.1.3
+Version: 1.1.3.9001
 Date: 2022-06-11
 License: MIT + file LICENSE
 URL: https://docs.ropensci.org/webchem/, https://github.com/ropensci/webchem

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# webchem dev
+
+## BUG FIXES
+
+* ChemSpider functions did not include time delays between queries. This has been fixed.
+
 # webchem 1.1.3
 
 ## NEW FEATURES

--- a/R/chemspider.R
+++ b/R/chemspider.R
@@ -221,6 +221,7 @@ get_csid <- function(query,
     }
     if (verbose) webchem_message("query", x, appendLF = FALSE)
     qurl <- paste0("https://api.rsc.org/compounds/v1/filter/", from)
+    webchem_sleep(type = 'API')
     postres <- try(httr::RETRY("POST",
                                url = qurl,
                                httr::add_headers(.headers = headers),
@@ -236,6 +237,7 @@ get_csid <- function(query,
       qurl <- paste0("https://api.rsc.org/compounds/v1/filter/",
                      query_id,
                      "/status")
+      webchem_sleep(type = 'API')
       getstatus <- try(httr::RETRY("GET",
                                    url = qurl,
                                    httr::add_headers(.headers = headers),
@@ -249,6 +251,7 @@ get_csid <- function(query,
         qurl <- paste0("https://api.rsc.org/compounds/v1/filter/",
                        query_id,
                        "/results")
+        webchem_sleep(type = 'API')
         getres <- try(httr::RETRY("GET",
                                   url = qurl,
                                   httr::add_headers(.headers = headers),
@@ -414,6 +417,7 @@ cs_convert <- function(query, from, to, verbose = getOption("verbose"),
     if (verbose) webchem_message("query", x, appendLF = FALSE)
     body <- jsonlite::toJSON(body, auto_unbox = TRUE)
     qurl <- "https://api.rsc.org/compounds/v1/tools/convert"
+    webchem_sleep(type = 'API')
     postres <- try(httr::RETRY("POST",
                                url = qurl,
                                httr::add_headers(.headers = headers),
@@ -497,6 +501,7 @@ cs_compinfo <- function(csid, fields, verbose = getOption("verbose"),
   body <- jsonlite::toJSON(body)
   if (verbose) webchem_message("query_all", appendLF = FALSE)
   qurl <- "https://api.rsc.org/compounds/v1/records/batch"
+  webchem_sleep(type = 'API')
   postres <- try(httr::RETRY("POST",
                              url = qurl,
                              httr::add_headers(.headers = headers),
@@ -646,6 +651,7 @@ cs_img <- function(csid,
     path <- paste0(dir, "/", csid, ".png")
     url <- paste0("https://api.rsc.org/compounds/v1/records/", csid, "/image")
     headers <- c("Content-Type" = "", "apikey" = apikey)
+    webchem_sleep(type = 'API')
     res <- try(httr::RETRY("GET",
                            url,
                            httr::add_headers(.headers = headers),

--- a/tests/testthat/test-bcpc.R
+++ b/tests/testthat/test-bcpc.R
@@ -17,8 +17,8 @@ test_that("examples in the article are unchanged as far as it can be reasonably 
   expect_type(igroup, "character")
   expect_equal(names(igroup), c("50-29-3", "52-68-6", "55-38-9"))
   expect_equal(unname(igroup), c("organochlorine",
-                                 "phosphonate insecticides",
-                                 "phenyl organothiophosphate insecticides"))
+                                 "phosphonate",
+                                 "phenyl organothiophosphate"))
 })
 
 test_that("BCPC pesticide compendium, name", {
@@ -71,11 +71,11 @@ test_that("BCPC pesticide compendium, activity", {
   comps <- c("atrazine", "2,4-D", "Copper hydroxide", "ziram")
   o1 <- bcpc_query(comps)
   expect_equal(o1[[1]]$activity, "herbicides")
-  expect_equal(o1[[1]]$subactivity, "chlorotriazine herbicides")
-  expect_equal(o1[[2]]$activity, c("herbicides", "plant growth regulators"))
-  expect_equal(o1[[2]]$subactivity, c("phenoxyacetic herbicides", "auxins"))
+  expect_equal(o1[[1]]$subactivity, "chlorotriazine")
+  expect_equal(o1[[2]]$activity, "herbicides")
+  expect_equal(o1[[2]]$subactivity, "phenoxyacetic")
   expect_equal(o1[[3]]$activity, c("bactericides", "fungicides"))
-  expect_equal(o1[[3]]$subactivity, c(NA, "copper fungicides"))
+  expect_equal(o1[[3]]$subactivity, c(NA, "copper compound"))
   expect_equal(o1[[4]]$activity, c("bird repellents", "fungicides", "mammal repellents"))
-  expect_equal(o1[[4]]$subactivity, c(NA, "dithiocarbamate fungicides; zinc fungicides", NA))
+  expect_equal(o1[[4]]$subactivity, c(NA, "dimethyldithiocarbamate; zinc compound", NA))
 })

--- a/tests/testthat/test-wikidata.R
+++ b/tests/testthat/test-wikidata.R
@@ -15,7 +15,7 @@ test_that("get_wdid returns correct results", {
   expect_s3_class(o3, 'data.frame')
   expect_s3_class(o4, 'data.frame')
 
-  expect_equal(o1$wdid, c("Q163648", "Q57731093", NA, 'Q47512'),
+  expect_equal(o1$wdid, c("Q163648", "Q20987744", NA, 'Q47512'),
                ignore_attr = TRUE)
   expect_equal(o2$wdid[1:2], c("Q163648", "Q949424"), ignore_attr = TRUE)
 })


### PR DESCRIPTION
This PR is related to Issue #368. ChemSpider functions did not contain any sleep, so queries were probably posted too quickly which triggered a temporary IP address blocking from the service provider. This PR adds the standard `webchem_sleep(type = "API")` before each ChemSpider request. 

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed