### PR TITLE
Update ChemSpider to accept API keys provided during function call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## BUG FIXES
 
 * ChemSpider functions did not include time delays between queries. This has been fixed.
+* Multiple ChemSpider functions failed when the API key was provided during function call. This has been fixed.
 
 ## NEW FEATURES
 

--- a/R/chemspider.R
+++ b/R/chemspider.R
@@ -188,7 +188,7 @@ get_csid <- function(query,
   }
   from <- match.arg(from)
   match <- match.arg(match)
-  if (!ping_service("cs")) stop(webchem_message("service_down"))
+  if (!ping_service("cs", apikey = apikey)) stop(webchem_message("service_down"))
   foo <- function(x, from, match, verbose, apikey, ...) {
     if (is.na(x)) {
       if (verbose) webchem_message("na")

--- a/man/ping_service.Rd
+++ b/man/ping_service.Rd
@@ -6,11 +6,16 @@
 \usage{
 ping_service(
   service = c("bcpc", "chebi", "chembl", "ci", "cs", "cs_web", "cir", "cts", "etox",
-    "fn", "nist", "opsin", "pan", "pc", "srs", "wd")
+    "fn", "nist", "opsin", "pan", "pc", "srs", "wd"),
+  apikey = NULL
 )
 }
 \arguments{
-\item{service}{character; the same abbreviations used as prefixes in \code{webchem} functions, with the exception of \code{"cs_web"}, which only checks if the ChemSpider website is up, and thus doesn't require an API key.}
+\item{service}{character; the same abbreviations used as prefixes in
+\code{webchem} functions, with the exception of \code{"cs_web"}, which only
+checks if the ChemSpider website is up, and thus doesn't require an API key.}
+
+\item{apikey}{character; API key for services that require API keys}
 }
 \value{
 A logical, TRUE if the service is available or FALSE if it isn't


### PR DESCRIPTION
Related to Issue #370.

The bug is caused by webchem's ping functionality. While most ChemSpider functions accept apikey as user input, `ping_cs()` uses `cs_check_key()` exclusively. This causes most ChemSpider functions to fail when neither .Renviron nor .Rprofiles contain an API key, regardless of whether the user provides an API key within the function call. This PR fixes this issue.

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed