### PR TITLE
Fix for #374, adds "µ" to column name.

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |
@@ -51,7 +51,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * ChemSpider functions did not include time delays between queries. This has been fixed.
 * Multiple ChemSpider functions failed when the API key was provided during function call. This has been fixed.
+* Minor change in NIST retention index tables was causing `nist_ri()` to fail.  This has been fixed.
 
 ## NEW FEATURES
 

--- a/R/nist.R
+++ b/R/nist.R
@@ -199,7 +199,7 @@ tidy_ritable <- function(ri_xml) {
                              "gas" = "Carrier gas",
                              "substrate" = "Substrate",
                              "diameter" = "Column diameter (mm)",
-                             "thickness" = "Phase thickness (m)",
+                             "thickness" = "Phase thickness (μm)",
                              "temp_start" = "Tstart (C)",
                              "temp_end" = "Tend (C)",
                              "temp_rate" = "Heat rate (K/min)",

--- a/R/nist.R
+++ b/R/nist.R
@@ -182,7 +182,7 @@ tidy_ritable <- function(ri_xml) {
                              "gas" = "Carrier gas",
                              "substrate" = "Substrate",
                              "diameter" = "Column diameter (mm)",
-                             "thickness" = "Phase thickness (m)",
+                             "thickness" = "Phase thickness (μm)",
                              "program" = "Program",
                              "reference" = "Reference",
                              "comment" = "Comment") %>%
@@ -232,7 +232,7 @@ tidy_ritable <- function(ri_xml) {
                              "gas" = "Carrier gas",
                              "substrate" = "Substrate",
                              "diameter" = "Column diameter (mm)",
-                             "thickness" = "Phase thickness (m)",
+                             "thickness" = "Phase thickness (μm)",
                              "temp" = "Temperature (C)",
                              "reference" = "Reference",
                              "comment" = "Comment") %>%

--- a/R/nist.R
+++ b/R/nist.R
@@ -182,7 +182,7 @@ tidy_ritable <- function(ri_xml) {
                              "gas" = "Carrier gas",
                              "substrate" = "Substrate",
                              "diameter" = "Column diameter (mm)",
-                             "thickness" = "Phase thickness (μm)",
+                             "thickness" = "Phase thickness (\u03bcm)",
                              "program" = "Program",
                              "reference" = "Reference",
                              "comment" = "Comment") %>%
@@ -199,7 +199,7 @@ tidy_ritable <- function(ri_xml) {
                              "gas" = "Carrier gas",
                              "substrate" = "Substrate",
                              "diameter" = "Column diameter (mm)",
-                             "thickness" = "Phase thickness (μm)",
+                             "thickness" = "Phase thickness (\u03bcm)",
                              "temp_start" = "Tstart (C)",
                              "temp_end" = "Tend (C)",
                              "temp_rate" = "Heat rate (K/min)",
@@ -232,7 +232,7 @@ tidy_ritable <- function(ri_xml) {
                              "gas" = "Carrier gas",
                              "substrate" = "Substrate",
                              "diameter" = "Column diameter (mm)",
-                             "thickness" = "Phase thickness (μm)",
+                             "thickness" = "Phase thickness (\u03bcm)",
                              "temp" = "Temperature (C)",
                              "reference" = "Reference",
                              "comment" = "Comment") %>%

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -149,7 +149,7 @@ test_that("pc_sect()", {
 
   a <- pc_sect(c(311, 176, 1118, "balloon", NA), "Dissociation Constants")
   expect_s3_class(a, c("tbl_df", "tbl", "data.frame"))
-  expect_equal(mean(c("Citric acid", "Acetic Acid", NA) %in% a$Name), 1)
+  expect_setequal(c("citric acid", "acetic acid", "sulfuric acid", NA), tolower(a$Name))
   expect_equal(mean(c("2.79", "4.76 (at 25 °C)", NA) %in% a$Result), 1)
   expect_equal(mean(c("DrugBank", NA) %in% a$SourceName), 1)
   expect_equal(mean(c("DB04272", "DB03166", NA) %in% a$SourceID), 1)


### PR DESCRIPTION
## Pull Request
Maybe the smallest PR in webchem history! Changes "Phase thickness (m)" to "Phase thickness (µm)" following an apparent change to the NIST website. (see #374 ).  Considered using something like `starts_with("Phase thickness")`, but I actually would prefer knowing about changes to things like this on NIST's end.

I also fixed a failing pubchem test.

I also updated the GH actions to use tagged versions of actions/cache, r-lib/actions/setup, etc.

PR task list:
- [x] Update NEWS
- [ ] Add tests (if appropriate)
- [ ] Update documentation with `devtools::document()`
- [ ] Check package passed