### PR TITLE
Fix pkgdown config

### DIFF
--- a/.github/workflows/check-pkgdown.yml
+++ b/.github/workflows/check-pkgdown.yml
@@ -1,0 +1,29 @@
+on:
+    push:
+      branches:
+        - master
+    pull_request:
+      branches:
+        - master
+  
+  name: check-pkgdown
+  
+  jobs:
+    check_pkgdown:
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@v3
+        - uses: r-lib/actions/setup-r@v2
+          with:
+            r-version: 'release'
+        - uses: r-lib/actions/setup-r-dependencies@v2
+          with:
+            extra-packages: any::devtools, any::pkgdown
+          
+        - name: Install dependencies
+          run: devtools::install_github("https://github.com/ropensci-org/rotemplate")
+          shell: Rscript {0}
+  
+        - name: Check pkgdown
+          run: pkgdown::check_pkgdown()
+          shell: Rscript {0}

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -23,6 +23,7 @@ reference:
   - ends_with("_query")
   - -opsin_query
   - chebi_comp_entity
+  - chembl_query
   - cs_compinfo
   - cs_extcompinfo
   - cts_compinfo
@@ -50,6 +51,8 @@ reference:
   - extractors
   - ping_service
   - cs_datasources
+  - chembl_atc_classes
+  - chembl_resources
   - parse_mol
   - write_mol
 - title: Deprecated and defunct


### PR DESCRIPTION
Related to #373. This PR adds three ChEMBL functions to the pkgdown configuration file and adds a new GitHub action to automate `pkgdown::check_pkgdown()`.

PR task list:
- [x] Update NEWS (not relevant)
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [ ] Check package passed