### PR TITLE
fix URL for pkgdown

### DIFF
--- a/R/chembl.R
+++ b/R/chembl.R
@@ -181,9 +181,8 @@ chembl_atc_classes <- function(verbose = getOption("verbose"),
 #'
 #' Data in ChEMBL is organized in databases called resources. This function
 #' lists available ChEMBL resources.
-#' @note The list was compiled manually using the following url: \url{
-#' https://chembl.gitbook.io/chembl-interface-documentation/web-services/
-#' chembl-data-web-services}
+#' @note The list was compiled manually using the following url:
+#' \url{https://chembl.gitbook.io/chembl-interface-documentation/web-services/chembl-data-web-services}
 #' @references Gaulton, A., Bellis, L. J., Bento, A. P., Chambers, J.,
 #' Davies, M., Hersey, A., ... & Overington, J. P. (2012). ChEMBL: a large-scale
 #' bioactivity database for drug discovery. Nucleic acids research, 40(D1),

--- a/man/chembl_resources.Rd
+++ b/man/chembl_resources.Rd
@@ -11,9 +11,8 @@ Data in ChEMBL is organized in databases called resources. This function
 lists available ChEMBL resources.
 }
 \note{
-The list was compiled manually using the following url: \url{
-https://chembl.gitbook.io/chembl-interface-documentation/web-services/
-chembl-data-web-services}
+The list was compiled manually using the following url:
+\url{https://chembl.gitbook.io/chembl-interface-documentation/web-services/chembl-data-web-services}
 }
 \references{
 Gaulton, A., Bellis, L. J., Bento, A. P., Chambers, J.,


### PR DESCRIPTION
On https://github.com/r-universe/ropensci/actions/runs/3379201731/jobs/5610451554 we see

```
Reading 'man/chembl_resources.Rd'
Error in .f(.x[[i]], ...) : Failed to parse Rd in chembl_resources.Rd
ℹ Failed to parse \url{}.
ℹ This may be caused by a \url tag that spans a line break.
```

This PR removes the error.