### PR TITLE
fix bug when search matches multiple records

### DIFF
--- a/R/nist.R
+++ b/R/nist.R
@@ -129,8 +129,6 @@ nist_ri <- function(query,
   querynames [is.na(querynames)] <- ".NA"
   names(ri_tables) <- querynames
 
-  # ri_tables <- purrr::map_dfr(ri_xmls, tidy_ritable, .id = "query") %>%
-  #   dplyr::mutate(query = na_if(query, ".NA"))
   ri_tables <- dplyr::bind_rows(ri_tables)
   return(ri_tables)
 }
@@ -146,6 +144,7 @@ nist_ri <- function(query,
 #' @noRd
 #' @import rvest
 #' @import xml2
+#' @importFrom utils URLencode
 #' @return an xml nodeset
 #'
 get_ri_xml <-
@@ -177,7 +176,7 @@ get_ri_xml <-
       ID <- paste0("C", gsub("-", "", query))
     }
     # check for existence of record
-      qurl <- paste0(baseurl, "?", from_str, "=", gsub(" ","+", query), "&Units=SI")
+      qurl <- URLencode(paste0(baseurl, "?", from_str, "=", gsub(" ","+", query), "&Units=SI"))
       webchem_sleep(type = 'scrape')
       if (verbose) webchem_message("query", query, appendLF = FALSE)
       res <- try_url(qurl)

--- a/R/nist.R
+++ b/R/nist.R
@@ -198,9 +198,11 @@ get_ri_xml <-
           ri_xml <- construct_NA_table(query)
         } else if (result == "Search Results") {
           # if more than one compound found
+          if (verbose){
           message(paste0(" More than one match for '", query,
                          "'. Returning NA."))
-          ri_xml <- dplyr::tibble(query = query)
+          }
+          ri_xml <- construct_NA_table(query)
         } else{
         links <-
           page %>%

--- a/R/nist.R
+++ b/R/nist.R
@@ -177,7 +177,7 @@ get_ri_xml <-
       ID <- paste0("C", gsub("-", "", query))
     }
     # check for existence of record
-      qurl <- paste0(baseurl, "?", from_str, "=", query, "&Units=SI")
+      qurl <- paste0(baseurl, "?", from_str, "=", gsub(" ","+", query), "&Units=SI")
       webchem_sleep(type = 'scrape')
       if (verbose) webchem_message("query", query, appendLF = FALSE)
       res <- try_url(qurl)

--- a/tests/testthat/test-nist.R
+++ b/tests/testthat/test-nist.R
@@ -154,11 +154,12 @@ test_that("a record with no CAS number returns expected output", {
 })
 
 test_that("nist_ri() can deal appropriately with a mixture of queries", {
-  test <- nist_ri(query=c(NA, "baloon", "methane", "hexanol"), from = "name",
+  test <- nist_ri(query=c(NA, "baloon", "methane", "deuterium", "hexanol"), from = "name",
                   type=c("kovats","linear"), polarity="polar",
                   temp_prog = "ramp")
 
   expect_true(all(is.na(test[1,])))
+
   expect_true(is.na(test[[2,"cas"]]))
   expect_true(is.na(test[[2,"RI"]]))
 
@@ -166,9 +167,12 @@ test_that("nist_ri() can deal appropriately with a mixture of queries", {
   expect_equal(test[[3,"cas"]], "74-82-8")
   expect_true(is.na(test[[3,"RI"]]))
 
-  expect_equal(test[[4,"query"]], "hexanol")
-  expect_equal(test[[4,"cas"]], "111-27-3")
-  expect_equal(test[[4,"RI"]], 1339)
+  expect_equal(test[[4,"query"]], "deuterium")
+  expect_true(all(is.na(test[4,-1])))
+
+  expect_equal(test[[5,"query"]], "hexanol")
+  expect_equal(test[[5,"cas"]], "111-27-3")
+  expect_equal(test[[5,"RI"]], 1339)
 })
 
 test_that("nist_ri() works with multiple temperature program arguments",{

--- a/tests/testthat/test-nist.R
+++ b/tests/testthat/test-nist.R
@@ -153,6 +153,13 @@ test_that("a record with no CAS number returns expected output", {
   expect_equal(test$cas, NA)
 })
 
+test_that("a query with spaces returns the expected output", {
+  test <- nist_ri(query = "methyl glyoxal", from="name",temp_prog = "ramp")
+  expect_equal(test$query, "methyl glyoxal")
+  expect_equal(test$cas, "78-98-8")
+  expect_true(!is.na(test[1,"RI"]))
+})
+
 test_that("nist_ri() can deal appropriately with a mixture of queries", {
   test <- nist_ri(query=c(NA, "baloon", "methane", "deuterium", "hexanol"), from = "name",
                   type=c("kovats","linear"), polarity="polar",


### PR DESCRIPTION
Sorry, I just found a bug that I introduced with the last pull request. It occurs when a query matches multiple records in the web book. This PR should fix the bug and also adds a test for this scenario.

PR task list:
- [ x] Update NEWS [I don't think it's necessary to update the NEWS for this...?]
- [ x] Add tests (if appropriate)
- [ x] Update documentation with `devtools::document()`
- [ x] Check package passed