### PR TITLE
update to actions/checkout@v3

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,7 @@ jobs:
       RSPM: ${{ matrix.config.rspm }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
   test-coverage:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -2,6 +2,7 @@
 # somewhat unreliable.
 
 etox_up <- ping_service("etox")
+fn_up <- ping_service("fn")
 up <- ping_service("cts")
 
 test_that("with_cts() works when no translation needed", {
@@ -17,11 +18,11 @@ test_that("with_cts() works when no translation needed", {
       .f = "get_etoxid",
       .verbose = getOption("verbose")
     )
-  b <- get_etoxid(CASs)
+  b <- get_etoxid(CASs, from = "cas")
   expect_equal(a, b)
 })
 
-etox_up <- ping_service("etox")
+
 test_that("with_cts() translates", {
   skip_on_cran()
   skip_if_not(etox_up, "ETOX down!")

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -1,12 +1,12 @@
 # These all might occasionally fail because cts_translate() is currently
 # somewhat unreliable.
 
-fn_up <- ping_service("fn")
+etox_up <- ping_service("etox")
 up <- ping_service("cts")
 
 test_that("with_cts() works when no translation needed", {
   skip_on_cran()
-  skip_if_not(fn_up, "Flavornet down!")
+  skip_if_not(etox_up, "ETOX down!")
   skip_if_not(up, "CTS service down")
 
   CASs <- c("75-07-0",  "64-17-5")
@@ -14,10 +14,10 @@ test_that("with_cts() works when no translation needed", {
     with_cts(
       query = CASs,
       from = "cas",
-      .f = "fn_percept",
+      .f = "get_etoxid",
       .verbose = getOption("verbose")
     )
-  b <- fn_percept(CASs)
+  b <- get_etoxid(CASs)
   expect_equal(a, b)
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -66,6 +66,7 @@ test_that("is.inchikey() returns correct results", {
 
 
 test_that("is.smiles() returns correct results", {
+  skip_if_not_installed("rcdk")
   expect_true(is.smiles('Clc1ccc(cc1)C(c2ccc(Cl)cc2)C(Cl)(Cl)Cl'))
   expect_false(suppressWarnings(
     is.smiles('Clc1ccc(cc1)C(c2ccc(Cl)cc2)C(Cl)(Cl)ClWWX')))


### PR DESCRIPTION
## Pull Request

I noticed warnings that actions/checkout@v2 is deprecated, this updates to v3

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if appropriate)
- [ ] Update documentation with `devtools::document()`
- [ ] Check package passed