### PR TITLE
Fix pc_sect() failing on certain CIDs

### DIFF
--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -641,6 +641,10 @@ pc_page <- function(id,
     if (verbose) message(httr::message_for_status(res))
     if (res$status_code == 200) {
       cont <- httr::content(res, type = "text", encoding = "UTF-8")
+      # Intercepting any NA cont before it gets to fromJSON.
+      if(is.na(cont)) {
+        return(NA)
+      }
       cont <- jsonlite::fromJSON(cont, simplifyDataFrame = FALSE)
       tree <- data.tree::as.Node(cont, nameName = "TOCHeading")
       tree$Do(function(node) node$name <- tolower(node$name))


### PR DESCRIPTION

Brief description of the PR

Fix for #354. @stitam and @sxthimons confirmed that the cause of pc_sect() sometimes failing with certain CIDs was that certain PubChem records would return NA by httr::content(), and NA as the txt argument in jsonlite::fromJSON() results in an error that halts code execution. Since pc_sect() is a function likely to be run in a loop, it seems better if pc_sect() fails silently on NA returned from httr::content() and continues instead of breaking the loop with an opaque error.

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if appropriate)
- [ ] Update documentation with `devtools::document()`
- [ ] Check package passed