### PR TITLE
Fix tests for NIST and ChEMBL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 
 * ci_query() has been removed from the package because NLM had retired ChemIDplus.
 
+## BUG FIXES
+
+* nist_ri() failed because the behaviour of a dependency had changed. This has been fixed.
+
 # webchem 1.2.0
 
 ## NEW FEATURES

--- a/R/nist.R
+++ b/R/nist.R
@@ -368,7 +368,7 @@ tidy_ritable <- function(ri_xml) {
 
     # make NAs explicit and gas abbreviations consistent
     output <- tidy2 %>%
-      dplyr::mutate_all(~ na_if(., "")) %>%
+      mutate(across(where(is.character), ~na_if(., ""))) %>%
       dplyr::mutate(
         gas = case_when(
           stringr::str_detect(gas, "He") ~ "Helium",

--- a/tests/testthat/test-chembl.R
+++ b/tests/testthat/test-chembl.R
@@ -14,7 +14,7 @@ test_that("chembl_query()", {
   o4 <- chembl_query("CHEMBL771355", resource = "assay")
 
   expect_type(o1, "list")
-  expect_equal(length(o1[[1]]), 38)
+  expect_equal(length(o1[[1]]), 34)
   expect_equal(o1m[2], "OK (HTTP 200).")
   expect_equal(length(o2), 2)
   expect_equal(o3[[1]]$entity_type, "ASSAY")


### PR DESCRIPTION
Related to Issue #391.

NIST: it seems the behaviour of some `dplyr` functions has changed which broke `nist_ri()`.
ChEMBL: `chembl_query()` used to return a list with 38 elements, now it returns a list with 34 elements.

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed