### PR TITLE
Reformat cas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The `nist_ri` function now returns a column with the CAS number to facilitate querying of multiple retention index tables.
 * The `nist_ri` function can now take multiple arguments for `type`, `polarity` and `temp_prog`.
+* CAS numbers are automatically reformatted using `as.cas` in `bcpc_query`, `cts_compinfo`, `cts_convert`, `get_etoxid`, `fn_percept`, `get_cid`, and `srs_query`.
+* The `as.cas` function now has a `verbose` argument.
 
 ## DEFUNCT FUNCTIONS
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * The `nist_ri` function now returns a column with the CAS number to facilitate querying of multiple retention index tables.
 * The `nist_ri` function can now take multiple arguments for `type`, `polarity` and `temp_prog`.
-* CAS numbers are automatically reformatted using `as.cas` in `bcpc_query`, `cts_compinfo`, `cts_convert`, `get_etoxid`, `fn_percept`, `get_cid`, and `srs_query`.
+* CAS numbers are automatically reformatted using `as.cas` in `bcpc_query`, `cts_convert`, `get_etoxid`, `fn_percept`, `get_cid`, and `srs_query`.
 * The `as.cas` function now has a `verbose` argument.
 
 ## DEFUNCT FUNCTIONS

--- a/R/bcpc.R
+++ b/R/bcpc.R
@@ -47,8 +47,11 @@ bcpc_query <- function(query, from = c("name", "cas"),
     message('To search by compound name use "name" instead of "commonname"')
     from <- "name"
   }
+
   from <- match.arg(from)
   bcpc_idx <- build_bcpc_idx(verbose, ...)
+
+  names(query) <- query
 
   foo <- function(query, from, verbose) {
     if (is.na(query)) {
@@ -64,6 +67,7 @@ bcpc_query <- function(query, from = c("name", "cas"),
     }
 
     if (from == "cas") {
+      query <- as.cas(query, verbose = verbose)
       names <- bcpc_idx$names[bcpc_idx$source == "rn"]
       # select only first link
       links <- bcpc_idx$links[bcpc_idx$source == "rn"]
@@ -164,7 +168,6 @@ bcpc_query <- function(query, from = c("name", "cas"),
     }
   }
   out <- lapply(query, function(x) foo(x, from = from, verbose = verbose))
-  names(out) <- query
   class(out) <- c("bcpc_query", "list")
   return(out)
 }

--- a/R/bcpc.R
+++ b/R/bcpc.R
@@ -54,6 +54,14 @@ bcpc_query <- function(query, from = c("name", "cas"),
   names(query) <- query
 
   foo <- function(query, from, verbose) {
+    if (from == "cas") {
+      query <- as.cas(query, verbose = verbose)
+      names <- bcpc_idx$names[bcpc_idx$source == "rn"]
+      # select only first link
+      links <- bcpc_idx$links[bcpc_idx$source == "rn"]
+      linknames <- bcpc_idx$linknames[bcpc_idx$source == "rn"]
+      cname <-  linknames[tolower(names) == tolower(query)]
+    }
     if (is.na(query)) {
       if (verbose) webchem_message("na")
       return(NA)
@@ -64,15 +72,6 @@ bcpc_query <- function(query, from = c("name", "cas"),
       links <- bcpc_idx$links[bcpc_idx$source == "cn"]
       names <- bcpc_idx$linknames[bcpc_idx$source == "cn"]
       cname <-  query
-    }
-
-    if (from == "cas") {
-      query <- as.cas(query, verbose = verbose)
-      names <- bcpc_idx$names[bcpc_idx$source == "rn"]
-      # select only first link
-      links <- bcpc_idx$links[bcpc_idx$source == "rn"]
-      linknames <- bcpc_idx$linknames[bcpc_idx$source == "rn"]
-      cname <-  linknames[tolower(names) == tolower(query)]
     }
 
     takelink <- links[tolower(names) == tolower(query)]

--- a/R/cts.R
+++ b/R/cts.R
@@ -45,9 +45,6 @@ cts_compinfo <- function(query, from = "inchikey",
       if (verbose) webchem_message("na")
       return(NA)
     }
-    if (from == "cas"){
-      query <- as.cas(query, verbose = verbose)
-    }
     if (verbose) webchem_message("query", query, appendLF = FALSE)
     if (!is.inchikey(query, verbose = FALSE)) {
       if (verbose) message("Input is not a valid inchikey.")
@@ -162,12 +159,12 @@ cts_convert <- function(query,
   }
 
   foo <- function(query, from, to, first, verbose){
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
     if (is.na(query)) {
       if (verbose) webchem_message("na")
       return(NA)
-    }
-    if (from == "CAS"){
-      query <- as.cas(query, verbose = verbose)
     }
     if (verbose) webchem_message("query", query, appendLF = FALSE)
     query <- URLencode(query, reserved = TRUE)

--- a/R/cts.R
+++ b/R/cts.R
@@ -167,7 +167,7 @@ cts_convert <- function(query,
       return(NA)
     }
     if (from == "CAS"){
-      query <- sapply(query, as.cas, verbose = verbose)
+      query <- as.cas(query, verbose = verbose)
     }
     if (verbose) webchem_message("query", query, appendLF = FALSE)
     query <- URLencode(query, reserved = TRUE)

--- a/R/cts.R
+++ b/R/cts.R
@@ -34,7 +34,7 @@ cts_compinfo <- function(query, from = "inchikey",
                          verbose = getOption("verbose"), inchikey){
 
   if (!ping_service("cts")) stop(webchem_message("service_down"))
-
+  names(query) <- query
   if (!missing(inchikey)) {
     message('"inchikey" is deprecated.  Please use "query" instead.')
     query <- inchikey
@@ -45,7 +45,10 @@ cts_compinfo <- function(query, from = "inchikey",
       if (verbose) webchem_message("na")
       return(NA)
     }
-    if(verbose) webchem_message("query", query, appendLF = FALSE)
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
+    if (verbose) webchem_message("query", query, appendLF = FALSE)
     if (!is.inchikey(query, verbose = FALSE)) {
       if (verbose) message("Input is not a valid inchikey.")
       return(NA)
@@ -72,7 +75,6 @@ cts_compinfo <- function(query, from = "inchikey",
     }
   }
   out <- lapply(query, foo, verbose = verbose)
-  names(out) <- query
   class(out) <- c('cts_compinfo','list')
   return(out)
 }
@@ -146,6 +148,7 @@ cts_convert <- function(query,
   }
 
   query <- as.character(query)
+  names(query) <- query
   from <-  match.arg(tolower(from), c(cts_from(), "name"))
   to <-  match.arg(tolower(to), c(cts_to(), "name"))
   match <- match.arg(match)
@@ -163,7 +166,10 @@ cts_convert <- function(query,
       if (verbose) webchem_message("na")
       return(NA)
     }
-    if(verbose) webchem_message("query", query, appendLF = FALSE)
+    if (from == "CAS"){
+      query <- sapply(query, as.cas, verbose = verbose)
+    }
+    if (verbose) webchem_message("query", query, appendLF = FALSE)
     query <- URLencode(query, reserved = TRUE)
     from <- URLencode(from, reserved = TRUE)
     to <- URLencode(to, reserved = TRUE)
@@ -197,7 +203,6 @@ cts_convert <- function(query,
   }
   out <- lapply(query, foo, from = from, to = to, first = first,
                 verbose = verbose)
-  names(out) <- query
   return(out)
 }
 

--- a/R/etox.R
+++ b/R/etox.R
@@ -48,7 +48,6 @@ get_etoxid <- function(query,
   if (!ping_service("etox")) stop(webchem_message("service_down"))
   names(query) <- query
 
-
   clean_char <- function(x) {
     # rm \n \t
     x <- gsub("\n | \t", "", x)
@@ -65,12 +64,12 @@ get_etoxid <- function(query,
     warning("match = 'best' only makes sense when querying chemical names. ")
   }
   foo <- function(query, from, match, verbose) {
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
     if (is.na(query)) {
       if (verbose) webchem_message("na")
       return(tibble("query" = query, "match" = NA, "etoxid" = NA))
-    }
-    if (from == "cas"){
-      query <- as.cas(query, verbose = verbose)
     }
     if (verbose) webchem_message("query", query, appendLF = FALSE)
     baseurl <- "https://webetox.uba.de/webETOX/public/search/stoff.do"

--- a/R/etox.R
+++ b/R/etox.R
@@ -131,7 +131,7 @@ get_etoxid <- function(query,
     }
   }
   out <- lapply(query, foo, from = from, match = match, verbose = verbose)
-  out <- dplyr::bind_rows(out)
+  out <- dplyr::bind_rows(out, .id = "query")
   return(out)
 }
 

--- a/R/etox.R
+++ b/R/etox.R
@@ -46,6 +46,8 @@ get_etoxid <- function(query,
                        verbose = getOption("verbose")) {
 
   if (!ping_service("etox")) stop(webchem_message("service_down"))
+  names(query) <- query
+
 
   clean_char <- function(x) {
     # rm \n \t
@@ -67,7 +69,10 @@ get_etoxid <- function(query,
       if (verbose) webchem_message("na")
       return(tibble("query" = query, "match" = NA, "etoxid" = NA))
     }
-    if(verbose) webchem_message("query", query, appendLF = FALSE)
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
+    if (verbose) webchem_message("query", query, appendLF = FALSE)
     baseurl <- "https://webetox.uba.de/webETOX/public/search/stoff.do"
     if (from == 'name') {
       body <- list("stoffname.selection[0].name" = query,
@@ -172,6 +177,7 @@ get_etoxid <- function(query,
 etox_basic <- function(id, verbose = getOption("verbose")) {
 
   if (!ping_service("etox")) stop(webchem_message("service_down"))
+  names(id) <- id
 
   foo <- function(id, verbose) {
     if (is.na(id)) {
@@ -252,7 +258,6 @@ etox_basic <- function(id, verbose = getOption("verbose")) {
     }
     }
   out <- lapply(id, foo, verbose = verbose)
-  names(out) <- id
   class(out) <- c('etox_basic', 'list')
   return(out)
 }
@@ -291,8 +296,8 @@ etox_basic <- function(id, verbose = getOption("verbose")) {
 #'
 #' }
 etox_targets <- function(id, verbose = getOption("verbose")) {
-
   if (!ping_service("etox")) stop(webchem_message("service_down"))
+  names(id) <- id
 
   foo <- function(id, verbose) {
     if (is.na(id)) {
@@ -356,7 +361,6 @@ etox_targets <- function(id, verbose = getOption("verbose")) {
     }
   }
   out <- lapply(id, foo, verbose = verbose)
-  names(out) <- id
   return(out)
 }
 
@@ -390,7 +394,7 @@ etox_targets <- function(id, verbose = getOption("verbose")) {
 etox_tests <- function(id, verbose = getOption("verbose")) {
 
   if (!ping_service("etox")) stop(webchem_message("service_down"))
-
+  names(id) <- id
   foo <- function(id, verbose){
     if (is.na(id)) {
       if (verbose) webchem_message("na")
@@ -448,6 +452,5 @@ etox_tests <- function(id, verbose = getOption("verbose")) {
     }
   }
   out <- lapply(id, foo, verbose = verbose)
-  names(out) <- id
   return(out)
 }

--- a/R/flavornet.R
+++ b/R/flavornet.R
@@ -36,12 +36,12 @@ fn_percept <- function(query, from = "cas", verbose = getOption("verbose"),
   match.arg(from)
   names(query) <- query
   foo <- function (query, verbose){
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
     if (is.na(query)) {
       if (verbose) webchem_message("na")
       return(NA)
-    }
-    if (from == "cas"){
-      query <- as.cas(query, verbose = verbose)
     }
     qurl <- paste0("http://www.flavornet.org/info/",query,".html")
     if (verbose) webchem_message("query", query, appendLF = FALSE)

--- a/R/flavornet.R
+++ b/R/flavornet.R
@@ -34,13 +34,17 @@ fn_percept <- function(query, from = "cas", verbose = getOption("verbose"),
     query <- CAS
   }
   match.arg(from)
+  names(query) <- query
   foo <- function (query, verbose){
     if (is.na(query)) {
       if (verbose) webchem_message("na")
       return(NA)
     }
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
     qurl <- paste0("http://www.flavornet.org/info/",query,".html")
-    if(verbose) webchem_message("query", query, appendLF = FALSE)
+    if (verbose) webchem_message("query", query, appendLF = FALSE)
     webchem_sleep(type = 'scrape')
     res <- try(httr::RETRY("GET",
                            qurl,
@@ -64,6 +68,5 @@ fn_percept <- function(query, from = "cas", verbose = getOption("verbose"),
     }
   }
   percepts <- sapply(query, foo, verbose = verbose)
-  names(percepts) <- query
   return(percepts)
 }

--- a/R/flavornet.R
+++ b/R/flavornet.R
@@ -1,6 +1,6 @@
 #' Retrieve flavor percepts from www.flavornet.org
 #'
-#' Retreive flavor percepts from \url{http://www.flavornet.org}.  Flavornet is a database of 738 compounds with odors
+#' Retrieve flavor percepts from \url{http://www.flavornet.org}.  Flavornet is a database of 738 compounds with odors
 #' perceptible to humans detected using gas chromatography olfactometry (GCO).
 #'
 #' @import xml2

--- a/R/pan.R
+++ b/R/pan.R
@@ -78,11 +78,15 @@ pan_query <- function(query, from = c("name", "cas"),
 
   match <- match.arg(match)
   from <- match.arg(from)
+  names(query) <- query
 
   foo <- function(query, match, from, verbose) {
     if (is.na(query)) {
       if (verbose) webchem_message("na")
       return(NA)
+    }
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
     }
     baseurl <- 'https://www.pesticideinfo.org/List_Chemicals.jsp?'
     baseq <- paste0('ChooseSearchType=Begin&ResultCnt=50&dCAS_No=y&dEPA_PCCode=y&',
@@ -162,7 +166,6 @@ pan_query <- function(query, from = c("name", "cas"),
     }
   }
   out <- lapply(query, foo, match = match, from = from, verbose = verbose)
-  names(out) <- query
   class(out) <- c('pan_query', 'list')
   return(out)
 }

--- a/R/pan.R
+++ b/R/pan.R
@@ -81,12 +81,12 @@ pan_query <- function(query, from = c("name", "cas"),
   names(query) <- query
 
   foo <- function(query, match, from, verbose) {
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
     if (is.na(query)) {
       if (verbose) webchem_message("na")
       return(NA)
-    }
-    if (from == "cas"){
-      query <- as.cas(query, verbose = verbose)
     }
     baseurl <- 'https://www.pesticideinfo.org/List_Chemicals.jsp?'
     baseq <- paste0('ChooseSearchType=Begin&ResultCnt=50&dCAS_No=y&dEPA_PCCode=y&',

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -19,8 +19,8 @@
 #' \code{domain}:
 #' \itemize{
 #' \item{\code{compound}: \code{"name"}, \code{"smiles"}, \code{"inchi"},
-#' \code{"inchikey"}, \code{"formula"}, \code{"sdf"}, <xref>,
-#' <structure search>, <fast search>.}
+#' \code{"inchikey"}, \code{"formula"}, \code{"sdf"}, \code{"cas"} (an alias for
+#' \code{"xref/RN"}), <xref>, <structure search>, <fast search>.}
 #' \item{\code{substance}: \code{"name"}, \code{"sid"},
 #' \code{<xref>}, \code{"sourceid/<source id>"} or \code{"sourceall"}.}
 #' \item{\code{assay}: \code{"aid"}, \code{<assay target>}.}

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -133,8 +133,9 @@ get_cid <-
   }
     #input validation
     from <- tolower(from)
-    if (from == "cas"){
-      query <- as.cas(query, verbose = verbose)
+    from <- ifelse(from == "cas", "xref/rn", from)
+    if (from == "xref/rn"){
+       query <- as.cas(query, verbose = verbose)
     }
     domain <- match.arg(domain)
     xref <- paste(

--- a/R/pubchem.R
+++ b/R/pubchem.R
@@ -133,6 +133,9 @@ get_cid <-
   }
     #input validation
     from <- tolower(from)
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
     domain <- match.arg(domain)
     xref <- paste(
       "xref",
@@ -468,6 +471,8 @@ pc_synonyms <- function(query,
   # from = "name"
   from <- match.arg(from)
   match <- match.arg(match)
+  names(query) <- query
+
   if (!missing("choices"))
     stop("'choices' is deprecated. Use 'match' instead.")
   foo <- function(query, from, verbose, ...) {
@@ -511,7 +516,6 @@ pc_synonyms <- function(query,
     }
   }
   out <- lapply(query, foo, from = from, verbose = verbose)
-  names(out) <- query
   if (!is.null(choices)) #if only one choice is returned, convert list to vector
     out <- unlist(out)
   return(out)

--- a/R/srs.R
+++ b/R/srs.R
@@ -30,10 +30,12 @@ srs_query <-
            verbose = getOption("verbose"), ...) {
 
     if (!ping_service("srs")) stop(webchem_message("service_down"))
-
+    names(query) <- query
     from <- match.arg(from)
     entity_url <- "https://cdxnodengn.epa.gov/cdx-srs-rest/"
-
+    if (from == "cas"){
+      query <- as.cas(query, verbose = verbose)
+    }
     rst <- lapply(query, function(x) {
       if (is.na(x)){
         if (verbose) webchem_message("na")
@@ -64,6 +66,5 @@ srs_query <-
         return(NA)
       }
     })
-    names(rst) <- query
     return(rst)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -418,7 +418,7 @@ write_mol <- function(x, file = "") {
 #' x = c(58082, 123456, "hexenol")
 #' as.cas(x)
 #'
-as.cas <- function(x, verbose = FALSE){
+as.cas <- function(x, verbose = getOption("verbose")){
   format.cas <- function(x){
     if(is.na(x)) {
       return(NA)

--- a/R/utils.R
+++ b/R/utils.R
@@ -410,7 +410,7 @@ write_mol <- function(x, file = "") {
 #' format or don't pass \code{\link{is.cas}}, \code{NA} is returned
 #' @param x numeric vector, or character vector of CAS numbers missing the
 #' hyphens
-#'
+#' @param verbose logical; should a verbose output be printed on the console?
 #' @return character vector of valid CAS numbers
 #' @seealso \code{\link{is.cas}}
 #' @export
@@ -418,7 +418,7 @@ write_mol <- function(x, file = "") {
 #' x = c(58082, 123456, "hexenol")
 #' as.cas(x)
 #'
-as.cas <- function(x){
+as.cas <- function(x, verbose = FALSE){
   format.cas <- function(x){
     if(is.na(x)) {
       return(NA)
@@ -426,13 +426,14 @@ as.cas <- function(x){
       return(x)
     } else {
       parsed <- gsub("([0-9]+)([0-9]{2})([0-9]{1})", '\\1-\\2-\\3', x)
-      pass <- is.cas(parsed)
+      pass <- is.cas(parsed, verbose = verbose)
       out <- ifelse(pass, parsed, NA)
       return(out)
     }
   }
-
-  sapply(x, format.cas, USE.NAMES = FALSE)
+  cas <- sapply(x, format.cas, USE.NAMES = TRUE)
+  names(cas) <- x
+  cas
 }
 
 

--- a/man/as.cas.Rd
+++ b/man/as.cas.Rd
@@ -4,11 +4,13 @@
 \alias{as.cas}
 \title{Format numbers as CAS numbers}
 \usage{
-as.cas(x)
+as.cas(x, verbose = FALSE)
 }
 \arguments{
 \item{x}{numeric vector, or character vector of CAS numbers missing the
 hyphens}
+
+\item{verbose}{logical; should a verbose output be printed on the console?}
 }
 \value{
 character vector of valid CAS numbers

--- a/man/as.cas.Rd
+++ b/man/as.cas.Rd
@@ -4,7 +4,7 @@
 \alias{as.cas}
 \title{Format numbers as CAS numbers}
 \usage{
-as.cas(x, verbose = FALSE)
+as.cas(x, verbose = getOption("verbose"))
 }
 \arguments{
 \item{x}{numeric vector, or character vector of CAS numbers missing the

--- a/man/fn_percept.Rd
+++ b/man/fn_percept.Rd
@@ -21,7 +21,7 @@ fn_percept(query, from = "cas", verbose = getOption("verbose"), CAS, ...)
 A named character vector containing flavor percepts or NA's in the case of CAS numbers that are not found
 }
 \description{
-Retreive flavor percepts from \url{http://www.flavornet.org}.  Flavornet is a database of 738 compounds with odors
+Retrieve flavor percepts from \url{http://www.flavornet.org}.  Flavornet is a database of 738 compounds with odors
 perceptible to humans detected using gas chromatography olfactometry (GCO).
 }
 \examples{

--- a/man/get_cid.Rd
+++ b/man/get_cid.Rd
@@ -48,8 +48,8 @@ Valid values for the \code{from} argument depend on the
 \code{domain}:
 \itemize{
 \item{\code{compound}: \code{"name"}, \code{"smiles"}, \code{"inchi"},
-\code{"inchikey"}, \code{"formula"}, \code{"sdf"}, <xref>,
-<structure search>, <fast search>.}
+\code{"inchikey"}, \code{"formula"}, \code{"sdf"}, \code{"cas"} (an alias for
+\code{"xref/RN"}), <xref>, <structure search>, <fast search>.}
 \item{\code{substance}: \code{"name"}, \code{"sid"},
 \code{<xref>}, \code{"sourceid/<source id>"} or \code{"sourceall"}.}
 \item{\code{assay}: \code{"aid"}, \code{<assay target>}.}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -28,7 +28,7 @@ test_that("is.cas() returns correct results", {
 })
 
 test_that("as.cas() handles properly formatted CAS",{
-  expect_identical(as.cas("64-17-5"), "64-17-5")
+  expect_equal(as.cas("64-17-5"), "64-17-5", ignore_attr=TRUE)
   expect_silent(as.cas("64-17-5"))
 })
 


### PR DESCRIPTION
- CAS numbers are automatically reformatted using `as.cas` in bcpc, cts, etox, flavornet, pan, pubchem, srs functions.
- Adds `verbose` argument to `as.cas`.
- Changes the behavior of `as.cas` so it returns a named character vector whose names are the character strings from the original query.
- Alters test for `as.cas` (since it now retains the names of the original query).
- This pull request also changes the way names are assigned to `lapply` output because I ran into a problem with the way the output was being formatted for "non-cas" cas numbers like "balloon".
- Updated NEWS

PR task list:
- [ x] Update NEWS
- [ x] Add tests (if appropriate) [I didn't add any tests here, but let me know if you want me to add additional tests (e.g. that CAS numbers without dashes are being correctly reformatted).
- [x ] Update documentation with `devtools::document()`
- [ x] Check package passed