### PR TITLE
More edits before releasing v1.3.0

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -489,7 +489,7 @@ matcher <-
         if (length(x) != length(result))
           stop("Can't use match = 'best' without query matches for each output")
         if (verbose) message("Returning best.")
-        dd <- adist(query, result) / nchar(result)
+        dd <- utils::adist(query, result) / nchar(result)
         return(x[which.min(dd)])
       } else if (match == "first") {
         if (verbose) message("Returning first.")

--- a/R/webchem-defunct.R
+++ b/R/webchem-defunct.R
@@ -78,45 +78,6 @@ ci_query <- function() {
   )
 }
 
-cas.ci_query <- function() {
-  .Defunct(
-    "cas.ci_query",
-    package = "webchem",
-    msg = paste0(
-      "cas.ci_query() has been removed from the package because NLM had ",
-      "retired ChemIDplus. According to NLM all data found in ChemIDplus is ",
-      "available in PubChem. 'webchem' provides a number of functions for ",
-      "programmatically accessing PubChem."
-    )
-  )
-}
-
-inchikey.ci_query <- function() {
-  .Defunct(
-    "inchikey.ci_query",
-    package = "webchem",
-    msg = paste0(
-      "inchikey.ci_query() has been removed from the package because NLM had ",
-      "retired ChemIDplus. According to NLM all data found in ChemIDplus is ",
-      "available in PubChem. 'webchem' provides a number of functions for ",
-      "programmatically accessing PubChem."
-    )
-  )
-}
-
-smiles.ci_query <- function() {
-  .Defunct(
-    "smiles.ci_query",
-    package = "webchem",
-    msg = paste0(
-      "smiles.ci_query() has been removed from the package because NLM had ",
-      "retired ChemIDplus. According to NLM all data found in ChemIDplus is ",
-      "available in PubChem. 'webchem' provides a number of functions for ",
-      "programmatically accessing PubChem."
-    )
-  )
-}
-
 #' @rdname webchem-defunct
 #' @export
 pan_query <- function() {
@@ -126,41 +87,6 @@ pan_query <- function() {
     msg = paste0(
       "pan_query() has been removed from the package because programmatic ",
       "access to the Pesticide Action Network database is no longer supported."
-    )
-  )
-}
-
-cas.pan_query <- function() {
-  .Defunct(
-    "cas.pan_query",
-    package = "webchem",
-    msg = paste0(
-      "cas.pan_query() has been removed from the package because programmatic ",
-      "access to the Pesticide Action Network database is no longer supported."
-    )
-  )
-}
-
-inchikey.pan_query <- function() {
-  .Defunct(
-    "inchikey.pan_query",
-    package = "webchem",
-    msg = paste0(
-      "inchikey.pan_query() has been removed from the package because ",
-      "programmatic access to the Pesticide Action Network database is no ",
-      "longer supported."
-    )
-  )
-}
-
-smiles.pan_query <- function() {
-  .Defunct(
-    "smiles.pan_query",
-    package = "webchem",
-    msg = paste0(
-      "smiles.pan_query() has been removed from the package because ",
-      "programmatic access to the Pesticide Action Network database is no ",
-      "longer supported."
     )
   )
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,7 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "webchem",
-  "description": "Chemical information from around the web. This package interacts with a suite of web services for chemical information. Sources include: Alan Wood's Compendium of Pesticide Common Names, Chemical Identifier Resolver, ChEBI, Chemical Translation Service, ChemSpider, ETOX, Flavornet, NIST Chemistry WebBook, OPSIN, PAN Pesticide Database, PubChem, SRS, Wikidata.",
+  "description": "Chemical information from around the web. This package interacts with a suite of web services for chemical information. Sources include: Alan Wood's Compendium of Pesticide Common Names, Chemical Identifier Resolver, ChEBI, Chemical Translation Service, ChemSpider, ETOX, Flavornet, NIST Chemistry WebBook, OPSIN, PubChem, SRS, Wikidata.",
   "name": "webchem: Chemical Information from the Web",
   "relatedLink": ["https://docs.ropensci.org/webchem/", "https://CRAN.R-project.org/package=webchem"],
   "codeRepository": "https://github.com/ropensci/webchem",
@@ -350,7 +350,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "667.224KB",
+  "fileSize": "626.9KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,8 @@
+# webchem 1.3.0
+
+* This minor relese defuncts two functions, `ci_query()` and `pan_query()` because the webservices they were interacting with are no longer available.
+* Submission was rejected on 2023-05-04 due to the following check log entry: "Apparent methods for exported generics not registered: cas.ci_query inchikey.ci_query smiles.ci_query". This has been fixed.
+
 # webchem 1.1.3
 
 * Found the following (possibly) invalid URLs: https://www.gsbl.de (moved to 


### PR DESCRIPTION
CRAN submission was rejected on 2023-05-04 because of a check log entry: 
`Apparent methods for exported generics not registered: cas.ci_query inchikey.ci_query smiles.ci_query`
This PR fixes this by removing the extractors that are associated with defunct functions.

Other than this, the PR includes minor changes and new comments for the CRAN submission.

PR task list:
- [x] Update NEWS
- [x] Update documentation with `devtools::document()`
- [x] Check package passed