### PR TITLE
Expand use of `vcr` in testing

### DIFF
--- a/.github/workflows/check-api-stability.yaml
+++ b/.github/workflows/check-api-stability.yaml
@@ -1,0 +1,35 @@
+# Workflow derived from
+# https://github.com/r-lib/actions/blob/v2-branch/examples/check-standard.yaml
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    cron: "0 12 * * 0"
+
+name: Run tests without {vcr}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      VCR_TURN_OFF: true
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::testthat
+
+      - name: run tests
+        run: |
+          testthat::test_local()

--- a/tests/fixtures/chebi-article.yml
+++ b/tests/fixtures/chebi-article.yml
@@ -1,0 +1,542 @@
+http_interactions:
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |-
+        <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:23 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>563-12-2</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:24 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:38663</chebiId><chebiAsciiName>ethion</chebiAsciiName><searchScore>0.51</searchScore><entityStar>3</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>96182-53-5</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:24 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:38951</chebiId><chebiAsciiName>tebupirimfos</chebiAsciiName><searchScore>0.55</searchScore><entityStar>3</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>3383-96-8</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:24 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:38954</chebiId><chebiAsciiName>temephos</chebiAsciiName><searchScore>0.53</searchScore><entityStar>3</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |-
+        <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:26 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getCompleteEntity>
+                    <chebi:chebiId>CHEBI:38663</chebi:chebiId>
+                  </chebi:getCompleteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:26 GMT
+    body:
+      encoding: ''
+      file: no
+      string: "<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><getCompleteEntityResponse
+        xmlns=\"https://www.ebi.ac.uk/webservices/chebi\"><return><chebiId>CHEBI:38663</chebiId><chebiAsciiName>ethion</chebiAsciiName><definition>An
+        organic thiophosphate that is S,S'-methanediyl bis[dihydrogen (phosphorodithioate)]
+        in which all the hydroxy groups have been converted to their corresponding
+        ethyl esters respectively. Ethion is an organophosphate insecticide with inhibitory
+        activity towards the enzyme acetylcholinesterase ( EC 3.1.1.7).</definition><status>CHECKED</status><smiles>CCOP(=S)(OCC)SCSP(=S)(OCC)OCC</smiles><inchi>InChI=1S/C9H22O4P2S4/c1-5-10-14(16,11-6-2)18-9-19-15(17,12-7-3)13-8-4/h5-9H2,1-4H3</inchi><inchiKey>RIZMRRKBZQXFOY-UHFFFAOYSA-N</inchiKey><charge>0</charge><mass>384.48010</mass><monoisotopicMass>383.98762</monoisotopicMass><entityStar>3</entityStar><Synonyms><data>Bis(S-(diethoxyphosphinothioyl)mercapto)methane</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>O,O,O',O'-tetraethyl
+        S,S'-methanediyl bis(dithiophosphate)</data><type>SYNONYM</type><source>IUPAC</source></Synonyms><Synonyms><data>O,O,O',O'-Tetraethyl
+        S,S'-methylenebis(phosphorodithioate)</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>S,S'-Methylene
+        bis(O,O-diethyl phosphorodithioate)</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><IupacNames><data>O,O,O',O'-tetraethyl
+        S,S'-methanediyl bis(phosphorodithioate)</data><type>IUPAC NAME</type><source>IUPAC</source></IupacNames><Formulae><data>C9H22O4P2S4</data><source>ChemIDplus</source></Formulae><RegistryNumbers><data>1804530</data><type>Beilstein
+        Registry Number</type><source>Beilstein</source></RegistryNumbers><RegistryNumbers><data>1804530</data><type>Reaxys
+        Registry Number</type><source>Reaxys</source></RegistryNumbers><RegistryNumbers><data>563-12-2</data><type>CAS
+        Registry Number</type><source>KEGG COMPOUND</source></RegistryNumbers><RegistryNumbers><data>563-12-2</data><type>CAS
+        Registry Number</type><source>ChemIDplus</source></RegistryNumbers><RegistryNumbers><data>563-12-2</data><type>CAS
+        Registry Number</type><source>NIST Chemistry WebBook</source></RegistryNumbers><Citations><data>21366965</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>21560835</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>23127602</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>24398360</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>24401442</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><ChemicalStructures><structure>\n
+        \ Marvin  06250717252D          \n\n 19 18  0  0  0  0            999 V2000\n
+        \  -4.9063    0.6875    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -4.1918
+        \   1.1000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.3339    1.1000
+        \   0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    2.2385    0.6875    0.0000
+        C   0  0  0  0  0  0  0  0  0  0  0  0\n   -3.4773    0.6875    0.0000 O   0
+        \ 0  0  0  0  0  0  0  0  0  0  0\n    0.8095    0.6875    0.0000 O   0  0
+        \ 0  0  0  0  0  0  0  0  0  0\n    1.5240    1.1000    0.0000 C   0  0  0
+        \ 0  0  0  0  0  0  0  0  0\n   -2.7628    1.9250    0.0000 S   0  0  0  0
+        \ 0  0  0  0  0  0  0  0\n    0.0950    1.9250    0.0000 S   0  0  0  0  0
+        \ 0  0  0  0  0  0  0\n   -0.6194    0.6875    0.0000 S   0  0  0  0  0  0
+        \ 0  0  0  0  0  0\n   -2.0484    0.6875    0.0000 S   0  0  0  0  0  0  0
+        \ 0  0  0  0  0\n   -2.7628    1.1000    0.0000 P   0  0  3  0  0  0  0  0
+        \ 0  0  0  0\n    0.0950    1.1000    0.0000 P   0  0  3  0  0  0  0  0  0
+        \ 0  0  0\n   -2.9764    0.3031    0.0000 O   0  0  0  0  0  0  0  0  0  0
+        \ 0  0\n   -2.3930   -0.2803    0.0000 C   0  0  0  0  0  0  0  0  0  0  0
+        \ 0\n   -2.6065   -1.0771    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n
+        \   0.3086    0.3031    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.2748
+        \  -0.2803    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.0613   -1.0771
+        \   0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n  1  2  1  0  0  0  0\n
+        \ 2  5  1  0  0  0  0\n  5 12  1  0  0  0  0\n 12 11  1  0  0  0  0\n 11  3
+        \ 1  0  0  0  0\n  3 10  1  0  0  0  0\n 10 13  1  0  0  0  0\n 13  6  1  0
+        \ 0  0  0\n  6  7  1  0  0  0  0\n  7  4  1  0  0  0  0\n 12 14  1  0  0  0
+        \ 0\n 13 17  1  0  0  0  0\n 12  8  2  0  0  0  0\n 13  9  2  0  0  0  0\n
+        14 15  1  0  0  0  0\n 15 16  1  0  0  0  0\n 17 18  1  0  0  0  0\n 18 19
+        \ 1  0  0  0  0\nM  END\n</structure><type>mol</type><dimension>2D</dimension><defaultStructure>true</defaultStructure></ChemicalStructures><DatabaseLinks><data>276</data><type>PPDB
+        accession</type></DatabaseLinks><DatabaseLinks><data>C18725</data><type>KEGG
+        COMPOUND accession</type></DatabaseLinks><DatabaseLinks><data>Ethion</data><type>Wikipedia
+        accession</type></DatabaseLinks><OntologyParents><chebiName>insecticide</chebiName><chebiId>CHEBI:24852</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>environmental
+        contaminant</chebiName><chebiId>CHEBI:78298</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>EC
+        3.1.1.7 (acetylcholinesterase) inhibitor</chebiName><chebiId>CHEBI:38462</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>organic
+        thiophosphate</chebiName><chebiId>CHEBI:37512</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>acaricide</chebiName><chebiId>CHEBI:22153</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>agrochemical</chebiName><chebiId>CHEBI:33286</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents></return></getCompleteEntityResponse></S:Body></S:Envelope>"
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getCompleteEntity>
+                    <chebi:chebiId>CHEBI:38951</chebi:chebiId>
+                  </chebi:getCompleteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:26 GMT
+    body:
+      encoding: ''
+      file: no
+      string: "<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><getCompleteEntityResponse
+        xmlns=\"https://www.ebi.ac.uk/webservices/chebi\"><return><chebiId>CHEBI:38951</chebiId><chebiAsciiName>tebupirimfos</chebiAsciiName><definition></definition><status>CHECKED</status><smiles>CCOP(=S)(OC(C)C)Oc1cnc(nc1)C(C)(C)C</smiles><inchi>InChI=1S/C13H23N2O3PS/c1-7-16-19(20,17-10(2)3)18-11-8-14-12(15-9-11)13(4,5)6/h8-10H,7H2,1-6H3</inchi><inchiKey>AWYOMXWDGWUJHS-UHFFFAOYSA-N</inchiKey><charge>0</charge><mass>318.37316</mass><monoisotopicMass>318.11670</monoisotopicMass><entityStar>3</entityStar><Synonyms><data>O-(2-(1,1-Dimethylethyl)-5-pyrimidinyl)
+        O-ethyl O-(1-methylethyl) phosphorothioate</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>O-(2-tert-butylpyrimidin-5-yl)
+        O-ethyl O-isopropyl thiophosphate</data><type>SYNONYM</type><source>IUPAC</source></Synonyms><Synonyms><data>Phosphorothioic
+        acid, O-(2-(1,1-dimethylethyl)-5-pyrimidinyl) O-ethyl O-(1-methylethyl) ester</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>Phostebupirim</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>Tebupirimphos</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><IupacNames><data>O-(2-tert-butylpyrimidin-5-yl)
+        O-ethyl O-(propan-2-yl) phosphorothioate</data><type>IUPAC NAME</type><source>IUPAC</source></IupacNames><Formulae><data>C13H23N2O3PS</data><source>ChemIDplus</source></Formulae><RegistryNumbers><data>96182-53-5</data><type>CAS
+        Registry Number</type><source>KEGG COMPOUND</source></RegistryNumbers><RegistryNumbers><data>96182-53-5</data><type>CAS
+        Registry Number</type><source>ChemIDplus</source></RegistryNumbers><ChemicalStructures><structure>\n
+        \ Marvin  07230717102D          \n\n 20 20  0  0  0  0            999 V2000\n
+        \  -1.2315    2.5065    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.2315
+        \   1.6815    0.0000 P   0  0  3  0  0  0  0  0  0  0  0  0\n   -1.6440    0.9670
+        \   0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.2315    0.2526    0.0000
+        C   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.6440   -0.4619    0.0000 C   0
+        \ 0  0  0  0  0  0  0  0  0  0  0\n   -1.9460    1.2690    0.0000 O   0  0
+        \ 0  0  0  0  0  0  0  0  0  0\n   -3.3749    1.2690    0.0000 C   0  0  0
+        \ 0  0  0  0  0  0  0  0  0\n   -2.6605    1.6815    0.0000 C   0  0  3  0
+        \ 0  0  0  0  0  0  0  0\n   -2.6605    2.5065    0.0000 C   0  0  0  0  0
+        \ 0  0  0  0  0  0  0\n   -0.5170    1.2690    0.0000 O   0  0  0  0  0  0
+        \ 0  0  0  0  0  0\n    0.1974    1.6815    0.0000 C   0  0  0  0  0  0  0
+        \ 0  0  0  0  0\n    0.1974    2.5065    0.0000 C   0  0  0  0  0  0  0  0
+        \ 0  0  0  0\n    0.9119    1.2690    0.0000 C   0  0  0  0  0  0  0  0  0
+        \ 0  0  0\n    0.9119    2.9190    0.0000 N   0  0  0  0  0  0  0  0  0  0
+        \ 0  0\n    1.6264    1.6815    0.0000 N   0  0  0  0  0  0  0  0  0  0  0
+        \ 0\n    1.6264    2.5065    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n
+        \   2.1273    3.7159    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    2.9242
+        \   2.3357    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    2.3408    2.9190
+        \   0.0000 C   0  0  3  0  0  0  0  0  0  0  0  0\n    3.0553    3.3315    0.0000
+        C   0  0  0  0  0  0  0  0  0  0  0  0\n  2  1  2  0  0  0  0\n  2  6  1  0
+        \ 0  0  0\n  2 10  1  0  0  0  0\n  2  3  1  0  0  0  0\n  3  4  1  0  0  0
+        \ 0\n  4  5  1  0  0  0  0\n  6  8  1  0  0  0  0\n  8  7  1  0  0  0  0\n
+        \ 8  9  1  0  0  0  0\n 10 11  1  0  0  0  0\n 12 11  2  0  0  0  0\n 11 13
+        \ 1  0  0  0  0\n 14 12  1  0  0  0  0\n 14 16  2  0  0  0  0\n 13 15  2  0
+        \ 0  0  0\n 15 16  1  0  0  0  0\n 16 19  1  0  0  0  0\n 19 17  1  0  0  0
+        \ 0\n 19 18  1  0  0  0  0\n 19 20  1  0  0  0  0\nM  END\n</structure><type>mol</type><dimension>2D</dimension><defaultStructure>true</defaultStructure></ChemicalStructures><DatabaseLinks><data>1572</data><type>PPDB
+        accession</type></DatabaseLinks><DatabaseLinks><data>C18692</data><type>KEGG
+        COMPOUND accession</type></DatabaseLinks><OntologyParents><chebiName>EC 3.1.1.7
+        (acetylcholinesterase) inhibitor</chebiName><chebiId>CHEBI:38462</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>organic
+        thiophosphate</chebiName><chebiId>CHEBI:37512</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>organothiophosphate
+        insecticide</chebiName><chebiId>CHEBI:25715</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>2-tert-butylpyrimidin-5-ol</chebiName><chebiId>CHEBI:38952</chebiId><type>has
+        functional parent</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents></return></getCompleteEntityResponse></S:Body></S:Envelope>"
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getCompleteEntity>
+                    <chebi:chebiId>CHEBI:38954</chebi:chebiId>
+                  </chebi:getCompleteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:33:27 GMT
+    body:
+      encoding: ''
+      file: no
+      string: |-
+        <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getCompleteEntityResponse xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><chebiId>CHEBI:38954</chebiId><chebiAsciiName>temephos</chebiAsciiName><definition>An organic sulfide that is diphenyl sulfide in which the hydrogen at the para position of each of the phenyl groups has been replaced by a (dimethoxyphosphorothioyl)oxy group.</definition><status>CHECKED</status><smiles>S=P(OC)(OC1=CC=C(C=C1)SC2=CC=C(C=C2)OP(=S)(OC)OC)OC</smiles><inchi>InChI=1S/C16H20O6P2S3/c1-17-23(25,18-2)21-13-5-9-15(10-6-13)27-16-11-7-14(8-12-16)22-24(26,19-3)20-4/h5-12H,1-4H3</inchi><inchiKey>WWJZWCUNLNYYAU-UHFFFAOYSA-N</inchiKey><charge>0</charge><mass>466.473</mass><monoisotopicMass>465.98973</monoisotopicMass><entityStar>3</entityStar><Synonyms><data>Abate</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>O,O'-(thiodi-4,1-phenylene) bis(O,O-dimethyl phosphorothioate)</data><type>SYNONYM</type><source>Alan Wood's Pesticides</source></Synonyms><Synonyms><data>O,O'-(Thiodi-p-phenylene) O,O,O',O'-tetramethyl bis(phosphorothioate)</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>O,O,O',O'-tetramethyl O,O'-(sulfanediyldi-4,1-phenylene) bis(phosphorothioate)</data><type>SYNONYM</type><source>Alan Wood's Pesticides</source></Synonyms><Synonyms><data>O,O,O',O'-tetramethyl O,O'-(sulfanediyldibenzene-4,1-diyl) bis(thiophosphate)</data><type>SYNONYM</type><source>IUPAC</source></Synonyms><Synonyms><data>O,O,O',O'-tetramethyl O,O'-thiodi-p-phenylene bis(phosphorothioate)</data><type>SYNONYM</type><source>Alan Wood's Pesticides</source></Synonyms><Synonyms><data>O,O,O',O'-tetramethyl O,O'-thiodi-p-phenylene diphosphorothioate</data><type>SYNONYM</type><source>Alan Wood's Pesticides</source></Synonyms><Synonyms><data>Phosphorothioic acid, O,O'-(thiodi-4,1-phenylene) O,O,O',O'-tetramethyl ester</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>temefos</data><type>SYNONYM</type><source>Alan Wood's Pesticides</source><Comments><text>While 'temephos' is the ISO-approved name, the name 'temefos' is approved by the World Health Organization.</text><date>2016-12-15</date></Comments></Synonyms><Synonyms><data>temephos</data><type>SYNONYM</type><source>ChEBI</source></Synonyms><IupacNames><data>O,O,O',O'-tetramethyl O,O'-(sulfanediyldibenzene-4,1-diyl) bis(phosphorothioate)</data><type>IUPAC NAME</type><source>IUPAC</source></IupacNames><Formulae><data>C16H20O6P2S3</data><source>ChEBI</source></Formulae><RegistryNumbers><data>1896901</data><type>Beilstein Registry Number</type><source>Beilstein</source></RegistryNumbers><RegistryNumbers><data>3383-96-8</data><type>CAS Registry Number</type><source>Alan Wood's Pesticides</source></RegistryNumbers><RegistryNumbers><data>3383-96-8</data><type>CAS Registry Number</type><source>ChemIDplus</source></RegistryNumbers><RegistryNumbers><data>3383-96-8</data><type>CAS Registry Number</type><source>NIST Chemistry WebBook</source></RegistryNumbers><Citations><data>27180726</data><type>PubMed citation</type><source>Europe PMC</source></Citations><Citations><data>27419140</data><type>PubMed citation</type><source>Europe PMC</source></Citations><ChemicalStructures><structure>
+          Ketcher 12151613312D 1   1.00000     0.00000     0
+
+         27 28  0     0  0            999 V2000
+            8.8962  -20.1508    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+            8.8962  -21.1509    0.0000 P   0  0  0  0  0  0  0  0  0  0  0  0
+            8.0300  -21.6509    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+            7.1640  -21.1509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+            9.7623  -21.6509    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           10.6284  -21.1509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           12.3605  -21.1510    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           11.4945  -21.6510    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           10.6284  -20.1509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           11.4946  -19.6509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           12.3606  -20.1509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           13.2268  -19.6509    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+           13.2268  -18.6509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           14.0929  -18.1508    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           12.3607  -18.1508    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           12.3608  -17.1507    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           14.0930  -17.1507    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           13.2269  -16.6507    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           13.2308  -15.6564    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           12.3405  -14.1705    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+           12.3566  -15.1704    0.0000 P   0  0  0  0  0  0  0  0  0  0  0  0
+           11.4987  -15.6845    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           10.6247  -15.1985    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           12.1210  -16.1416    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           11.1615  -16.4233    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+            8.6266  -22.1181    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+            7.6581  -22.3673    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          2  1  2  0     0  0
+          2  3  1  0     0  0
+          2  5  1  0     0  0
+          3  4  1  0     0  0
+          5  6  1  0     0  0
+          8  6  2  0     0  0
+          6  9  1  0     0  0
+          7  8  1  0     0  0
+          7 11  2  0     0  0
+          9 10  2  0     0  0
+         10 11  1  0     0  0
+         11 12  1  0     0  0
+         12 13  1  0     0  0
+         14 13  2  0     0  0
+         13 15  1  0     0  0
+         14 17  1  0     0  0
+         15 16  2  0     0  0
+         16 18  1  0     0  0
+         18 17  2  0     0  0
+         18 19  1  0     0  0
+         19 21  1  0     0  0
+         21 20  2  0     0  0
+         21 22  1  0     0  0
+         22 23  1  0     0  0
+         21 24  1  0     0  0
+         24 25  1  0     0  0
+          2 26  1  0     0  0
+         26 27  1  0     0  0
+        M  END
+        </structure><type>mol</type><dimension>2D</dimension><defaultStructure>true</defaultStructure></ChemicalStructures><ChemicalStructures><structure>
+          Ketcher 12151613312D 1   1.00000     0.00000     0
+
+         27 28  0     0  0            999 V2000
+            8.4616  -17.1640    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+            8.4616  -18.1639    0.0000 P   0  0  0  0  0  0  0  0  0  0  0  0
+            7.5955  -18.6638    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+            6.7297  -18.1639    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+            9.3275  -18.6638    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           10.1934  -18.1639    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           11.0593  -16.6640    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           10.1934  -17.1640    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           11.0593  -18.6638    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           11.9252  -18.1639    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           11.9252  -17.1640    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           12.7912  -16.6640    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+           13.6570  -17.1640    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           14.5230  -16.6640    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           13.6570  -18.1639    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           14.5230  -18.6638    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           15.3889  -17.1640    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           15.3889  -18.1639    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           16.2548  -18.6638    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           17.1207  -17.1640    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+           17.1207  -18.1639    0.0000 P   0  0  0  0  0  0  0  0  0  0  0  0
+           17.9867  -18.6638    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           18.8525  -18.1639    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+           17.3719  -19.1309    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+           18.3358  -19.3969    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+            8.1921  -19.1309    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+            7.2236  -19.3800    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          2  1  2  0     0  0
+          2  3  1  0     0  0
+          2  5  1  0     0  0
+          3  4  1  0     0  0
+          5  6  1  0     0  0
+          8  6  2  0     0  0
+          6  9  1  0     0  0
+          7  8  1  0     0  0
+          7 11  2  0     0  0
+          9 10  2  0     0  0
+         10 11  1  0     0  0
+         11 12  1  0     0  0
+         12 13  1  0     0  0
+         14 13  2  0     0  0
+         13 15  1  0     0  0
+         14 17  1  0     0  0
+         15 16  2  0     0  0
+         16 18  1  0     0  0
+         18 17  2  0     0  0
+         18 19  1  0     0  0
+         19 21  1  0     0  0
+         21 20  2  0     0  0
+         21 22  1  0     0  0
+         22 23  1  0     0  0
+         21 24  1  0     0  0
+         24 25  1  0     0  0
+          2 26  1  0     0  0
+         26 27  1  0     0  0
+        M  END
+        </structure><type>mol</type><dimension>2D</dimension><defaultStructure>false</defaultStructure></ChemicalStructures><DatabaseLinks><data>618</data><type>VSDB accession</type></DatabaseLinks><DatabaseLinks><data>618</data><type>PPDB accession</type></DatabaseLinks><DatabaseLinks><data>C18809</data><type>KEGG COMPOUND accession</type></DatabaseLinks><DatabaseLinks><data>D06062</data><type>KEGG DRUG accession</type></DatabaseLinks><DatabaseLinks><data>LSM-3148</data><type>LINCS accession</type></DatabaseLinks><DatabaseLinks><data>temephos</data><type>Pesticides accession</type></DatabaseLinks><OntologyParents><chebiName>organic sulfide</chebiName><chebiId>CHEBI:16385</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>EC 3.1.1.7 (acetylcholinesterase) inhibitor</chebiName><chebiId>CHEBI:38462</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>organic thiophosphate</chebiName><chebiId>CHEBI:37512</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>organothiophosphate insecticide</chebiName><chebiId>CHEBI:25715</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>acaricide</chebiName><chebiId>CHEBI:22153</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>agrochemical</chebiName><chebiId>CHEBI:33286</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>ectoparasiticide</chebiName><chebiId>CHEBI:38956</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>4,4'-thiodiphenol</chebiName><chebiId>CHEBI:38957</chebiId><type>has functional parent</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents></return></getCompleteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:33:27 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0

--- a/tests/fixtures/chebi-correct.yml
+++ b/tests/fixtures/chebi-correct.yml
@@ -1,0 +1,720 @@
+http_interactions:
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |-
+        <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:25 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>Glyphosate</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:25 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:27744</chebiId><chebiAsciiName>glyphosate</chebiAsciiName><searchScore>0.95</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:133673</chebiId><chebiAsciiName>glyphosate(1-)</chebiAsciiName><searchScore>0.83</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:67052</chebiId><chebiAsciiName>glyphosate(2-)</chebiAsciiName><searchScore>0.67</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:81834</chebiId><chebiAsciiName>glyphosate-isopropylammonium</chebiAsciiName><searchScore>0.34</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:81835</chebiId><chebiAsciiName>Glyphosate-monoammonium</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:28812</chebiId><chebiAsciiName>(aminomethyl)phosphonic
+        acid</chebiAsciiName><searchScore>0.06</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:142824</chebiId><chebiAsciiName>saflufenacil</chebiAsciiName><searchScore>0.05</searchScore><entityStar>3</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |-
+        <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:25 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:26 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>glyphosate</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:26 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:27744</chebiId><chebiAsciiName>glyphosate</chebiAsciiName><searchScore>0.95</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:133673</chebiId><chebiAsciiName>glyphosate(1-)</chebiAsciiName><searchScore>0.83</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:67052</chebiId><chebiAsciiName>glyphosate(2-)</chebiAsciiName><searchScore>0.67</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:81834</chebiId><chebiAsciiName>glyphosate-isopropylammonium</chebiAsciiName><searchScore>0.34</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:81835</chebiId><chebiAsciiName>Glyphosate-monoammonium</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:28812</chebiId><chebiAsciiName>(aminomethyl)phosphonic
+        acid</chebiAsciiName><searchScore>0.06</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:142824</chebiId><chebiAsciiName>saflufenacil</chebiAsciiName><searchScore>0.05</searchScore><entityStar>3</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>balloon</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:26 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return/></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |-
+        <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:27 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getCompleteEntity>
+                    <chebi:chebiId>CHEBI:27744</chebi:chebiId>
+                  </chebi:getCompleteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:27 GMT
+    body:
+      encoding: ''
+      file: no
+      string: "<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><getCompleteEntityResponse
+        xmlns=\"https://www.ebi.ac.uk/webservices/chebi\"><return><chebiId>CHEBI:27744</chebiId><chebiAsciiName>glyphosate</chebiAsciiName><definition>A
+        phosphonic acid resulting from the formal oxidative coupling of the methyl
+        group of methylphosphonic acid with the amino group of glycine. It is one
+        of the most commonly used herbicides worldwide, and the only one to target
+        the enzyme 5-enolpyruvyl-3-shikimate phosphate synthase (EPSPS).</definition><status>CHECKED</status><smiles>OC(=O)CNCP(O)(O)=O</smiles><inchi>InChI=1S/C3H8NO5P/c5-3(6)1-4-2-10(7,8)9/h4H,1-2H2,(H,5,6)(H2,7,8,9)</inchi><inchiKey>XDDAORKBJWWYJS-UHFFFAOYSA-N</inchiKey><charge>0</charge><mass>169.07310</mass><monoisotopicMass>169.01401</monoisotopicMass><entityStar>3</entityStar><SecondaryChEBIIds>CHEBI:5510</SecondaryChEBIIds><SecondaryChEBIIds>CHEBI:24423</SecondaryChEBIIds><SecondaryChEBIIds>CHEBI:43013</SecondaryChEBIIds><Synonyms><data>Glyphosate</data><type>SYNONYM</type><source>KEGG
+        COMPOUND</source></Synonyms><Synonyms><data>Roundup</data><type>BRAND NAME</type><source>KEGG
+        COMPOUND</source></Synonyms><IupacNames><data>N-(phosphonomethyl)glycine</data><type>IUPAC
+        NAME</type><source>IUPAC</source></IupacNames><Formulae><data>C3H8NO5P</data><source>KEGG
+        COMPOUND</source></Formulae><RegistryNumbers><data>1071-83-6</data><type>CAS
+        Registry Number</type><source>KEGG COMPOUND</source></RegistryNumbers><RegistryNumbers><data>1071-83-6</data><type>CAS
+        Registry Number</type><source>Alan Wood's Pesticides</source></RegistryNumbers><RegistryNumbers><data>1071-83-6</data><type>CAS
+        Registry Number</type><source>ChemIDplus</source></RegistryNumbers><RegistryNumbers><data>2045054</data><type>Beilstein
+        Registry Number</type><source>Beilstein</source></RegistryNumbers><RegistryNumbers><data>279222</data><type>Gmelin
+        Registry Number</type><source>Gmelin</source></RegistryNumbers><Citations><data>27758090</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>28266132</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>28474816</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>28643882</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>28711546</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>30471482</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>30875550</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>31030151</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>31342895</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><ChemicalStructures><structure>\n
+        \ Marvin  01291313162D          \n\n 10  9  0  0  0  0            999 V2000\n
+        \  15.6197  -10.4907    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n   15.6197
+        \ -11.8188    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   16.7788  -12.4874
+        \   0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n   14.4609  -12.4874    0.0000
+        C   0  0  0  0  0  0  0  0  0  0  0  0\n   13.3112  -11.8188    0.0000 N   0
+        \ 0  0  0  0  0  0  0  0  0  0  0\n   12.1614  -12.4874    0.0000 C   0  0
+        \ 0  0  0  0  0  0  0  0  0  0\n   11.0026  -11.8188    0.0000 P   0  0  0
+        \ 0  0  0  0  0  0  0  0  0\n   11.0086  -10.4958    0.0000 O   0  0  0  0
+        \ 0  0  0  0  0  0  0  0\n    9.8548  -12.4988    0.0000 O   0  0  0  0  0
+        \ 0  0  0  0  0  0  0\n   10.6560  -13.1077    0.0000 O   0  0  0  0  0  0
+        \ 0  0  0  0  0  0\n  1  2  2  0  0  0  0\n  2  3  1  0  0  0  0\n  2  4  1
+        \ 0  0  0  0\n  4  5  1  0  0  0  0\n  5  6  1  0  0  0  0\n  6  7  1  0  0
+        \ 0  0\n  7  8  2  0  0  0  0\n  7  9  1  0  0  0  0\n  7 10  1  0  0  0  0\nM
+        \ END\n</structure><type>mol</type><dimension>2D</dimension><defaultStructure>true</defaultStructure></ChemicalStructures><ChemicalStructures><structure>ChEBI\n
+        \ Marvin  01291313172D          \n\n 10  9  0  0  0  0            999 V2000\n
+        \   9.1576   -5.8060    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n    8.7451
+        \  -6.5204    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    9.1576   -7.2349
+        \   0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n    7.9201   -6.5204    0.0000
+        C   0  0  0  0  0  0  0  0  0  0  0  0\n    7.5076   -7.2349    0.0000 N   0
+        \ 0  0  0  0  0  0  0  0  0  0  0\n    6.6826   -7.2349    0.0000 C   0  0
+        \ 0  0  0  0  0  0  0  0  0  0\n    6.2701   -7.9493    0.0000 P   0  0  0
+        \ 0  0  0  0  0  0  0  0  0\n    6.9846   -8.3618    0.0000 O   0  0  0  0
+        \ 0  0  0  0  0  0  0  0\n    5.8576   -8.6639    0.0000 O   0  0  0  0  0
+        \ 0  0  0  0  0  0  0\n    5.5556   -7.5368    0.0000 O   0  0  0  0  0  0
+        \ 0  0  0  0  0  0\n  1  2  2  0  0  0  0\n  2  3  1  0  0  0  0\n  2  4  1
+        \ 0  0  0  0\n  4  5  1  0  0  0  0\n  5  6  1  0  0  0  0\n  6  7  1  0  0
+        \ 0  0\n  7  8  1  0  0  0  0\n  7  9  1  0  0  0  0\n  7 10  2  0  0  0  0\nM
+        \ END\n</structure><type>mol</type><dimension>2D</dimension><defaultStructure>false</defaultStructure></ChemicalStructures><DatabaseLinks><data>373</data><type>PPDB
+        accession</type></DatabaseLinks><DatabaseLinks><data>c0134</data><type>UM-BBD
+        compID</type></DatabaseLinks><DatabaseLinks><data>C01705</data><type>KEGG
+        COMPOUND accession</type></DatabaseLinks><DatabaseLinks><data>DB04539</data><type>DrugBank
+        accession</type></DatabaseLinks><DatabaseLinks><data>glyphosate</data><type>Pesticides
+        accession</type></DatabaseLinks><DatabaseLinks><data>Glyphosate</data><type>Wikipedia
+        accession</type></DatabaseLinks><DatabaseLinks><data>GPF</data><type>PDBeChem
+        accession</type></DatabaseLinks><DatabaseLinks><data>GPJ</data><type>PDBeChem
+        accession</type></DatabaseLinks><OntologyParents><chebiName>glyphosate(1-)</chebiName><chebiId>CHEBI:133673</chebiId><type>is
+        conjugate acid of</type><status>CHECKED</status><cyclicRelationship>true</cyclicRelationship></OntologyParents><OntologyParents><chebiName>agrochemical</chebiName><chebiId>CHEBI:33286</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>phosphonic
+        acid</chebiName><chebiId>CHEBI:44976</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>glycine
+        derivative</chebiName><chebiId>CHEBI:24373</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>glyphosate(2-)</chebiName><chebiId>CHEBI:67052</chebiId><type>is
+        conjugate acid of</type><status>CHECKED</status><cyclicRelationship>true</cyclicRelationship></OntologyParents><OntologyParents><chebiName>EC
+        2.5.1.19 (3-phosphoshikimate 1-carboxyvinyltransferase) inhibitor</chebiName><chebiId>CHEBI:20569</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>herbicide</chebiName><chebiId>CHEBI:24527</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyChildren><chebiName>glyphosate(1-)</chebiName><chebiId>CHEBI:133673</chebiId><type>is
+        conjugate base of</type><status>CHECKED</status><cyclicRelationship>true</cyclicRelationship></OntologyChildren><OntologyChildren><chebiName>glyphosate(2-)</chebiName><chebiId>CHEBI:67052</chebiId><type>is
+        conjugate base of</type><status>CHECKED</status><cyclicRelationship>true</cyclicRelationship></OntologyChildren></return></getCompleteEntityResponse></S:Body></S:Envelope>"
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |-
+        <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:27 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getCompleteEntity>
+                    <chebi:chebiId>27732</chebi:chebiId>
+                  </chebi:getCompleteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:27 GMT
+    body:
+      encoding: ''
+      file: no
+      string: "<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><getCompleteEntityResponse
+        xmlns=\"https://www.ebi.ac.uk/webservices/chebi\"><return><chebiId>CHEBI:27732</chebiId><chebiAsciiName>caffeine</chebiAsciiName><definition>A
+        trimethylxanthine in which the three methyl groups are located at positions
+        1, 3, and 7. A purine alkaloid that occurs naturally in tea and coffee.</definition><status>CHECKED</status><smiles>Cn1cnc2n(C)c(=O)n(C)c(=O)c12</smiles><inchi>InChI=1S/C8H10N4O2/c1-10-4-9-6-5(10)7(13)12(3)8(14)11(6)2/h4H,1-3H3</inchi><inchiKey>RYYVLZVUVIJVGH-UHFFFAOYSA-N</inchiKey><charge>0</charge><mass>194.19076</mass><monoisotopicMass>194.08038</monoisotopicMass><entityStar>3</entityStar><SecondaryChEBIIds>CHEBI:3295</SecondaryChEBIIds><SecondaryChEBIIds>CHEBI:41472</SecondaryChEBIIds><SecondaryChEBIIds>CHEBI:22982</SecondaryChEBIIds><Synonyms><data>1,3,7-trimethyl-2,6-dioxopurine</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>1,3,7-trimethylpurine-2,6-dione</data><type>SYNONYM</type><source>IUPHAR</source></Synonyms><Synonyms><data>1,3,7-Trimethylxanthine</data><type>SYNONYM</type><source>KEGG
+        COMPOUND</source></Synonyms><Synonyms><data>1,3,7-trimethylxanthine</data><type>SYNONYM</type><source>NIST
+        Chemistry WebBook</source></Synonyms><Synonyms><data>1-methyltheobromine</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>3,7-Dihydro-1,3,7-trimethyl-1H-purin-2,6-dion</data><type>SYNONYM</type><source>NIST
+        Chemistry WebBook</source></Synonyms><Synonyms><data>7-methyltheophylline</data><type>SYNONYM</type><source>NIST
+        Chemistry WebBook</source></Synonyms><Synonyms><data>anhydrous caffeine</data><type>SYNONYM</type><source>KEGG
+        DRUG</source></Synonyms><Synonyms><data>cafeina</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>cafeine</data><type>SYNONYM</type><source>ChEBI</source></Synonyms><Synonyms><data>CAFFEINE</data><type>SYNONYM</type><source>PDBeChem</source></Synonyms><Synonyms><data>Caffeine</data><type>SYNONYM</type><source>KEGG
+        COMPOUND</source></Synonyms><Synonyms><data>caffeine</data><type>SYNONYM</type><source>UniProt</source></Synonyms><Synonyms><data>Coffein</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>guaranine</data><type>SYNONYM</type><source>IUPHAR</source></Synonyms><Synonyms><data>Koffein</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>mateina</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>methyltheobromine</data><type>SYNONYM</type><source>IUPHAR</source></Synonyms><Synonyms><data>teina</data><type>SYNONYM</type><source>ChEBI</source></Synonyms><Synonyms><data>Thein</data><type>SYNONYM</type><source>ChemIDplus</source></Synonyms><Synonyms><data>theine</data><type>SYNONYM</type><source>NIST
+        Chemistry WebBook</source></Synonyms><IupacNames><data>1,3,7-trimethyl-3,7-dihydro-1H-purine-2,6-dione</data><type>IUPAC
+        NAME</type><source>IUPAC</source></IupacNames><Formulae><data>C8H10N4O2</data><source>KEGG
+        COMPOUND</source></Formulae><RegistryNumbers><data>103040</data><type>Gmelin
+        Registry Number</type><source>Gmelin</source></RegistryNumbers><RegistryNumbers><data>17705</data><type>Beilstein
+        Registry Number</type><source>Beilstein</source></RegistryNumbers><RegistryNumbers><data>17705</data><type>Reaxys
+        Registry Number</type><source>Reaxys</source></RegistryNumbers><RegistryNumbers><data>58-08-2</data><type>CAS
+        Registry Number</type><source>KEGG COMPOUND</source></RegistryNumbers><RegistryNumbers><data>58-08-2</data><type>CAS
+        Registry Number</type><source>NIST Chemistry WebBook</source></RegistryNumbers><RegistryNumbers><data>58-08-2</data><type>CAS
+        Registry Number</type><source>ChemIDplus</source></RegistryNumbers><Citations><data>10510174</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>10796597</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>10803761</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>10822912</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>10884512</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>10924888</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>10983026</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11014293</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11022879</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11209966</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11312039</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11410911</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11431501</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11815511</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>11949272</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>12397877</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>12457274</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>12574990</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>12915014</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>12943586</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>14521986</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>14607010</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>15257305</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>15280431</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>15681408</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>15718055</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>15840517</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>16143823</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>16391865</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>16528931</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>16644114</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>16709440</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>16805851</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>16856769</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>17132260</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>17387608</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>17508167</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>17724925</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>17932622</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>17957400</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>18068204</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>18258404</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>18421070</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>18513215</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>18625110</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>18647558</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>19007524</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>19047957</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>19084078</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>19088793</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>19418355</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>19879252</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>20164568</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>20470411</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>22114686</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>22770225</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>23551936</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>24039592</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>7441110</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>7689104</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>8332255</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>8347173</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>8679661</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>9063686</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>9067318</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>9132918</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><Citations><data>9218278</data><type>PubMed
+        citation</type><source>Europe PMC</source></Citations><ChemicalStructures><structure>\n
+        \ Marvin  02080816422D          \n\n 14 15  0  0  0  0            999 V2000\n
+        \  -0.7145   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.7145
+        \   0.4125    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n    0.7145   -0.4125
+        \   0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    0.7145    0.4125    0.0000
+        C   0  0  0  0  0  0  0  0  0  0  0  0\n    0.0000   -0.8250    0.0000 N   0
+        \ 0  0  0  0  0  0  0  0  0  0  0\n    0.0000    0.8250    0.0000 C   0  0
+        \ 0  0  0  0  0  0  0  0  0  0\n    1.4992    0.6674    0.0000 N   0  0  0
+        \ 0  0  0  0  0  0  0  0  0\n    1.4992   -0.6675    0.0000 N   0  0  0  0
+        \ 0  0  0  0  0  0  0  0\n    1.9841    0.0000    0.0000 C   0  0  0  0  0
+        \ 0  0  0  0  0  0  0\n   -1.4289   -0.8250    0.0000 O   0  0  0  0  0  0
+        \ 0  0  0  0  0  0\n    0.0001    1.6500    0.0000 O   0  0  0  0  0  0  0
+        \ 0  0  0  0  0\n    0.0001   -1.6500    0.0000 C   0  0  0  0  0  0  0  0
+        \ 0  0  0  0\n    1.7541    1.4520    0.0000 C   0  0  0  0  0  0  0  0  0
+        \ 0  0  0\n   -1.4289    0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  0
+        \ 0  0\n 10  1  2  0  0  0  0\n  1  2  1  0  0  0  0\n 14  2  1  0  0  0  0\n
+        \ 8  3  1  0  0  0  0\n  4  3  2  0  0  0  0\n  7  4  1  0  0  0  0\n  1  5
+        \ 1  0  0  0  0\n  5  3  1  0  0  0  0\n 12  5  1  0  0  0  0\n  6  2  1  0
+        \ 0  0  0\n  6  4  1  0  0  0  0\n 11  6  2  0  0  0  0\n  9  7  1  0  0  0
+        \ 0\n 13  7  1  0  0  0  0\n  9  8  2  0  0  0  0\nM  END\n</structure><type>mol</type><dimension>2D</dimension><defaultStructure>true</defaultStructure></ChemicalStructures><ChemicalStructures><structure>\n
+        \ Marvin  02080816422D          \n\n 14 15  0  0  0  0            999 V2000\n
+        \  -0.7145   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  4  0  0\n   -0.7145
+        \   0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  5  0  0\n    0.0000   -0.8250
+        \   0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0\n    0.7145    0.4125    0.0000
+        N   0  0  0  0  0  0  0  0  0  1  0  0\n    0.7145   -0.4125    0.0000 C   0
+        \ 0  0  0  0  0  0  0  0  2  0  0\n    0.0000    0.8250    0.0000 C   0  0
+        \ 0  0  0  0  0  0  0  6  0  0\n   -1.4992    0.6674    0.0000 N   0  0  0
+        \ 0  0  0  0  0  0  7  0  0\n   -1.4992   -0.6675    0.0000 N   0  0  0  0
+        \ 0  0  0  0  0  9  0  0\n   -1.9841    0.0000    0.0000 C   0  0  0  0  0
+        \ 0  0  0  0  8  0  0\n    1.4289   -0.8250    0.0000 O   0  0  0  0  0  0
+        \ 0  0  0  0  0  0\n   -0.0001    1.6500    0.0000 O   0  0  0  0  0  0  0
+        \ 0  0  0  0  0\n   -0.0001   -1.6500    0.0000 C   0  0  0  0  0  0  0  0
+        \ 0  0  0  0\n   -1.7541    1.4520    0.0000 C   0  0  0  0  0  0  0  0  0
+        \ 0  0  0\n    1.4289    0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  0
+        \ 0  0\n  8  1  1  0  0  0  0\n  2  1  2  0  0  0  0\n  7  2  1  0  0  0  0\n
+        \ 3  1  1  0  0  0  0\n  5  4  1  0  0  0  0\n  5  3  1  0  0  0  0\n 10  5
+        \ 2  0  0  0  0\n  6  2  1  0  0  0  0\n  6  4  1  0  0  0  0\n 11  6  2  0
+        \ 0  0  0\n  9  7  1  0  0  0  0\n  9  8  2  0  0  0  0\n 12  3  1  0  0  0
+        \ 0\n 13  7  1  0  0  0  0\n 14  4  1  0  0  0  0\nM  APO  3  12   1  13   1
+        \ 14   1\nM  STY  3   1 SUP   2 SUP   3 SUP\nM  SAL   1  1  12\nM  SBL   1
+        \ 1  13\nM  SMT   1 Me\nM  SAL   2  1  13\nM  SBL   2  1  14\nM  SMT   2 Me\nM
+        \ SAL   3  1  14\nM  SBL   3  1  15\nM  SMT   3 Me\nM  END\n</structure><type>mol</type><dimension>2D</dimension><defaultStructure>false</defaultStructure></ChemicalStructures><ChemicalStructures><structure>\n
+        \ Marvin  02080816533D          \n\n 24 25  0  0  0  0            999 V2000\n
+        \  -0.8679    0.6241   -0.3283 C   0  0  0  0  0  0  0  0  0  4  0  0\n    0.4615
+        \   0.7009    0.0829 C   0  0  0  0  0  0  0  0  0  5  0  0\n   -1.5328   -0.5430
+        \  -0.4078 N   0  0  0  0  0  0  0  0  0  3  0  0\n    0.4263   -1.6660    0.3115
+        N   0  0  0  0  0  0  0  0  0  1  0  0\n   -0.8724   -1.6645   -0.0706 C   0
+        \ 0  0  0  0  0  0  0  0  2  0  0\n    1.0847   -0.4998    0.4105 C   0  0
+        \ 0  0  0  0  0  0  0  6  0  0\n    0.8268    2.0015    0.0556 N   0  0  0
+        \ 0  0  0  0  0  0  7  0  0\n   -1.2810    1.8740   -0.5971 N   0  0  0  0
+        \ 0  0  0  0  0  9  0  0\n   -0.2509    2.6938   -0.3617 C   0  0  0  0  0
+        \ 0  0  0  0  8  0  0\n   -1.4930   -2.7256   -0.1152 O   0  0  0  0  0  0
+        \ 0  0  0  0  0  0\n    2.2466   -0.4019    0.7856 O   0  0  0  0  0  0  0
+        \ 0  0  0  0  0\n   -2.8808   -0.5274   -0.8405 C   0  0  0  0  0  0  0  0
+        \ 0  0  0  0\n    2.0890    2.5724    0.3917 C   0  0  0  0  0  0  0  0  0
+        \ 0  0  0\n    1.0842   -2.8976    0.5960 C   0  0  0  0  0  0  0  0  0  0
+        \ 0  0\n   -0.3058    3.7063   -0.4907 H   0  0  0  0  0  0  0  0  0  0  0
+        \ 0\n   -3.5287   -0.9307   -0.0601 H   0  0  0  0  0  0  0  0  0  0  0  0\n
+        \  -2.9888   -1.1295   -1.7447 H   0  0  0  0  0  0  0  0  0  0  0  0\n   -3.2978
+        \   0.4525   -1.0903 H   0  0  0  0  0  0  0  0  0  0  0  0\n    2.8617    2.1595
+        \  -0.2585 H   0  0  0  0  0  0  0  0  0  0  0  0\n    2.3281    2.3436    1.4313
+        H   0  0  0  0  0  0  0  0  0  0  0  0\n    2.1008    3.6589    0.2773 H   0
+        \ 0  0  0  0  0  0  0  0  0  0  0\n    1.0715   -3.5477   -0.2828 H   0  0
+        \ 0  0  0  0  0  0  0  0  0  0\n    0.5843   -3.4214    1.4149 H   0  0  0
+        \ 0  0  0  0  0  0  0  0  0\n    2.1343   -2.8322    0.8911 H   0  0  0  0
+        \ 0  0  0  0  0  0  0  0\n  8  1  4  0  0  0  0\n  2  1  4  0  0  0  0\n  7
+        \ 2  4  0  0  0  0\n  3  1  1  0  0  0  0\n  5  4  1  0  0  0  0\n  5  3  1
+        \ 0  0  0  0\n 10  5  2  0  0  0  0\n  6  2  1  0  0  0  0\n  6  4  1  0  0
+        \ 0  0\n 11  6  2  0  0  0  0\n  9  7  4  0  0  0  0\n  9  8  4  0  0  0  0\n
+        \ 9 15  1  0  0  0  0\n 12  3  1  0  0  0  0\n 13  7  1  0  0  0  0\n 14  4
+        \ 1  0  0  0  0\n 12 16  1  0  0  0  0\n 12 17  1  0  0  0  0\n 12 18  1  0
+        \ 0  0  0\n 13 19  1  0  0  0  0\n 13 20  1  0  0  0  0\n 13 21  1  0  0  0
+        \ 0\n 14 22  1  0  0  0  0\n 14 23  1  0  0  0  0\n 14 24  1  0  0  0  0\nM
+        \ APO  3  12   1  13   1  14   1\nM  STY  3   1 SUP   2 SUP   3 SUP\nM  SAL
+        \  1  4  12  16  17  18\nM  SBL   1  1  14\nM  SMT   1 Me\nM  SDS EXP  1   1\nM
+        \ SAL   2  4  13  19  20  21\nM  SBL   2  1  15\nM  SMT   2 Me\nM  SDS EXP
+        \ 1   2\nM  SAL   3  4  14  22  23  24\nM  SBL   3  1  16\nM  SMT   3 Me\nM
+        \ SDS EXP  1   3\nM  END\n</structure><type>mol</type><dimension>3D</dimension><defaultStructure>false</defaultStructure></ChemicalStructures><DatabaseLinks><data>1-3-7-TRIMETHYLXANTHINE</data><type>MetaCyc
+        accession</type></DatabaseLinks><DatabaseLinks><data>463</data><type>Drug
+        Central accession</type></DatabaseLinks><DatabaseLinks><data>C00001492</data><type>KNApSAcK
+        accession</type></DatabaseLinks><DatabaseLinks><data>C07481</data><type>KEGG
+        COMPOUND accession</type></DatabaseLinks><DatabaseLinks><data>Caffeine</data><type>Wikipedia
+        accession</type></DatabaseLinks><DatabaseLinks><data>CFF</data><type>PDBeChem
+        accession</type></DatabaseLinks><DatabaseLinks><data>D00528</data><type>KEGG
+        DRUG accession</type></DatabaseLinks><DatabaseLinks><data>DB00201</data><type>DrugBank
+        accession</type></DatabaseLinks><DatabaseLinks><data>HMDB0001847</data><type>HMDB
+        accession</type></DatabaseLinks><DatabaseLinks><data>LSM-2026</data><type>LINCS
+        accession</type></DatabaseLinks><OntologyParents><chebiName>EC 3.1.4.* (phosphoric
+        diester hydrolase) inhibitor</chebiName><chebiId>CHEBI:50218</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>mouse
+        metabolite</chebiName><chebiId>CHEBI:75771</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>geroprotector</chebiName><chebiId>CHEBI:176497</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>EC
+        2.7.11.1 (non-specific serine/threonine protein kinase) inhibitor</chebiName><chebiId>CHEBI:50925</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>ryanodine
+        receptor agonist</chebiName><chebiId>CHEBI:67114</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>fungal
+        metabolite</chebiName><chebiId>CHEBI:76946</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>purine
+        alkaloid</chebiName><chebiId>CHEBI:26385</chebiId><type>is a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>adenosine
+        A2A receptor antagonist</chebiName><chebiId>CHEBI:53121</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>psychotropic
+        drug</chebiName><chebiId>CHEBI:35471</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>diuretic</chebiName><chebiId>CHEBI:35498</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>food
+        additive</chebiName><chebiId>CHEBI:64047</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>adjuvant</chebiName><chebiId>CHEBI:60809</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>central
+        nervous system stimulant</chebiName><chebiId>CHEBI:35337</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>adenosine
+        receptor antagonist</chebiName><chebiId>CHEBI:71232</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>plant
+        metabolite</chebiName><chebiId>CHEBI:76924</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>human
+        blood serum metabolite</chebiName><chebiId>CHEBI:85234</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>environmental
+        contaminant</chebiName><chebiId>CHEBI:78298</chebiId><type>has role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>xenobiotic</chebiName><chebiId>CHEBI:35703</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>trimethylxanthine</chebiName><chebiId>CHEBI:27134</chebiId><type>is
+        a</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyParents><chebiName>mutagen</chebiName><chebiId>CHEBI:25435</chebiId><type>has
+        role</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyParents><OntologyChildren><chebiName>caffeine
+        monohydrate</chebiName><chebiId>CHEBI:31332</chebiId><type>has part</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyChildren><OntologyChildren><chebiName>8-(3-chlorostyryl)caffeine</chebiName><chebiId>CHEBI:53115</chebiId><type>has
+        functional parent</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyChildren><OntologyChildren><chebiName>sodium
+        caffeine benzoate</chebiName><chebiId>CHEBI:32140</chebiId><type>has part</type><status>CHECKED</status><cyclicRelationship>false</cyclicRelationship></OntologyChildren><GeneralComments><text>Stravs
+        M, Schymanski E, Singer H, Department of Environmental Chemistry, Eawag</text><date>2014-10-29</date></GeneralComments><CompoundOrigins><speciesText>Mus
+        musculus</speciesText><speciesAccession>NCBI:txid10090</speciesAccession><SourceType>PubMed
+        Id</SourceType><SourceAccession>19425150</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Theobroma
+        cacao</speciesText><speciesAccession>NCBI:txid3641</speciesAccession><SourceType>DOI</SourceType><SourceAccession>10.1016/S0031-9422(00)00169-2</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Camellia
+        sinensis</speciesText><speciesAccession>NCBI:txid4442</speciesAccession><SourceType>PubMed
+        Id</SourceType><SourceAccession>18068204</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Claviceps
+        sorghicola</speciesText><speciesAccession>NCBI:txid83213</speciesAccession><SourceType>DOI</SourceType><SourceAccession>10.1016/S0031-9422(00)00169-2</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><componentText>blood</componentText><componentAccession>UBERON:0000178</componentAccession><SourceType>Article</SourceType><SourceAccession>McPherson,
+        Richard A., ed. Tietz Clinical Guide to Laboratory</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><componentText>cerebrospinal
+        fluid</componentText><componentAccession>UBERON:0001359</componentAccession><SourceType>PubMed
+        Id</SourceType><SourceAccession>17684518</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><componentText>saliva</componentText><componentAccession>UBERON:0001836</componentAccession><SourceType>PubMed
+        Id</SourceType><SourceAccession>12097436</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><componentText>urine</componentText><componentAccession>BTO:0001419</componentAccession><SourceType>PubMed
+        Id</SourceType><SourceAccession>21389975</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><componentText>blood
+        serum</componentText><componentAccession>BTO:0000133</componentAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS90</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS88</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS266</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS263</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS124</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS264</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS93</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS87</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS90</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS267</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS265</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS100</SourceAccession></CompoundOrigins><CompoundOrigins><speciesText>Homo
+        sapiens</speciesText><speciesAccession>NCBI:txid9606</speciesAccession><SourceType>MetaboLights</SourceType><SourceAccession>MTBLS20</SourceAccession></CompoundOrigins></return></getCompleteEntityResponse></S:Body></S:Envelope>"
+  recorded_at: 2023-08-03 19:34:28 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0

--- a/tests/fixtures/chebi-smiles.yml
+++ b/tests/fixtures/chebi-smiles.yml
@@ -1,0 +1,86 @@
+http_interactions:
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |-
+        <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>triclosan</chebi:search>
+                    <chebi:searchCategory>ALL</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:28 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:164200</chebiId><chebiAsciiName>triclosan</chebiAsciiName><searchScore>0.88</searchScore><entityStar>3</entityStar></ListElement><ListElement><chebiId>CHEBI:89302</chebiId><chebiAsciiName>Triclosan
+        glucuronide</chebiAsciiName><searchScore>0.26</searchScore><entityStar>2</entityStar></ListElement><ListElement><chebiId>CHEBI:89301</chebiId><chebiAsciiName>Triclosan
+        sulfate</chebiAsciiName><searchScore>0.13</searchScore><entityStar>2</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:29 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: post
+    uri: http://www.ebi.ac.uk/webservices/chebi/2.0/webservice
+    body:
+      encoding: ''
+      string: |2-
+
+            <soapenv:Envelope
+             xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+             xmlns:chebi="https://www.ebi.ac.uk/webservices/chebi">
+              <soapenv:Header/>
+                <soapenv:Body>
+                  <chebi:getLiteEntity>
+                    <chebi:search>C#C</chebi:search>
+                    <chebi:searchCategory>SMILES</chebi:searchCategory>
+                    <chebi:maximumResults>200</chebi:maximumResults>
+                    <chebi:stars>ALL</chebi:stars>
+                  </chebi:getLiteEntity>
+                </soapenv:Body>
+             </soapenv:Envelope>
+    headers:
+      Accept: multipart/*
+      Content-Type: text/xml; charset=utf-8
+      SOAPAction: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      server: Apache-Coyote/1.1
+      content-type: text/xml;charset=utf-8
+      transfer-encoding: chunked
+      date: Thu, 03 Aug 2023 19:34:28 GMT
+    body:
+      encoding: ''
+      file: no
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><getLiteEntityResponse
+        xmlns="https://www.ebi.ac.uk/webservices/chebi"><return><ListElement><chebiId>CHEBI:27518</chebiId><chebiAsciiName>acetylene</chebiAsciiName><searchScore>5.01</searchScore><entityStar>3</entityStar></ListElement></return></getLiteEntityResponse></S:Body></S:Envelope>
+  recorded_at: 2023-08-03 19:34:29 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0

--- a/tests/fixtures/cts_compinfo.yml
+++ b/tests/fixtures/cts_compinfo.yml
@@ -1,0 +1,4203 @@
+http_interactions:
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:40 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:40 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:40 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:40 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:41 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:41 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:42 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:45 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:46 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:46 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:48 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:52 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:52 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:52 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:53 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-X
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Thu, 03 Aug 2023 19:55:55 GMT
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "Sorry, we couldn't find any matching results"
+        ]
+  recorded_at: 2023-08-03 19:55:55 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0

--- a/tests/fixtures/cts_convert.yml
+++ b/tests/fixtures/cts_convert.yml
@@ -1,0 +1,12283 @@
+http_interactions:
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:46 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:46 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:46 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:46 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/fromValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:46 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:47 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/toValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:47 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChI Code",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/convert/chemical%20name/inchikey/xxxx
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:47 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "\n[\n  {\n    \"fromIdentifier\": \"chemical name\",\n    \"searchTerm\":
+        \"xxxx\",\n    \"toIdentifier\": \"inchikey\",\n    \"result\": \n    [\n
+        \   ]\n  }\n]"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:48 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:48 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/fromValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:48 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:48 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/toValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:48 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChI Code",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/convert/chemical%20name/inchikey/Triclosan
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:49 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "\n[\n  {\n    \"fromIdentifier\": \"chemical name\",\n    \"searchTerm\":
+        \"Triclosan\",\n    \"toIdentifier\": \"inchikey\",\n    \"result\": \n    [\n
+        \     \"XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n    ]\n  }\n]"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/convert/chemical%20name/inchikey/Hexane
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:50 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "\n[\n  {\n    \"fromIdentifier\": \"chemical name\",\n    \"searchTerm\":
+        \"Hexane\",\n    \"toIdentifier\": \"inchikey\",\n    \"result\": \n    [\n
+        \     \"VLKZOEOYAKHREP-UHFFFAOYSA-N\",\n      \"XDTMQSROBMDMFD-UHFFFAOYSA-N\",\n
+        \     \"ZSIAUFGUXNUGDI-UHFFFAOYSA-N\"\n    ]\n  }\n]"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:50 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:50 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/fromValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:50 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:50 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/toValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:51 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChI Code",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/convert/chemical%20name/inchikey/triclosan
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:51 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "\n[\n  {\n    \"fromIdentifier\": \"chemical name\",\n    \"searchTerm\":
+        \"triclosan\",\n    \"toIdentifier\": \"inchikey\",\n    \"result\": \n    [\n
+        \     \"XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n    ]\n  }\n]"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:51 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:52 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/fromValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:52 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:52 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/toValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:52 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChI Code",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:52 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:53 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/fromValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:53 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:53 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/toValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:53 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChI Code",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/convert/pubchem%20cid/inchikey/180
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:53 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "\n[\n  {\n    \"fromIdentifier\": \"pubchem cid\",\n    \"searchTerm\":
+        \"180\",\n    \"toIdentifier\": \"inchikey\",\n    \"result\": \n    [\n      \"CSCPPACGZOOCGX-UHFFFAOYSA-N\"\n
+        \   ]\n  }\n]"
+  recorded_at: 2023-08-03 19:57:53 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0

--- a/tests/fixtures/cts_from-to.yml
+++ b/tests/fixtures/cts_from-to.yml
@@ -1,0 +1,1640 @@
+http_interactions:
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:54 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:54 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/toValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:54 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChI Code",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:54 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/compound/XEFQLINVKFYRCS-UHFFFAOYSA-N
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:54 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: "{\n  \"inchikey\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n  \"inchicode\":
+        \"InChI=1S/C12H7Cl3O2/c13-7-1-3-11(9(15)5-7)17-12-4-2-8(14)6-10(12)16/h1-6,16H\",\n
+        \ \"molweight\": 289.54204,\n  \"exactmass\": 287.95116,\n  \"formula\": \"C12H7Cl3O2\",\n
+        \ \"dataSourcesCount\": 120,\n  \"referencesCount\": 854,\n  \"pubmedHits\":
+        1547,\n  \"smiles\": \"\",\n  \"synonyms\": \n  [\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"Triclosan\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"Synonym\",\n      \"name\": \"DNDI1246774\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Allowed)\",\n      \"name\":
+        \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\": 0\n    },\n
+        \   {\n      \"type\": \"IUPAC Name (Preferred)\",\n      \"name\": \"Triclosan\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\":
+        \"triclosan\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Irgasan DP 30\",\n      \"score\": 0\n    },\n    {\n      \"type\":
+        \"Synonym\",\n      \"name\": \"CH-3565\",\n      \"score\": 0\n    },\n    {\n
+        \     \"type\": \"Synonym\",\n      \"name\": \"5-chloro-2-(2, 4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (CAS-like
+        Style)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Triclosan
+        (USP/INN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name
+        (Preferred)\",\n      \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"score\": 0\n    },\n    {\n      \"type\": \"IUPAC Name (Traditional)\",\n
+        \     \"name\": \"5-chloro-2-(2,4-dichlorophenoxy)phenol\",\n      \"score\":
+        0\n    },\n    {\n      \"type\": \"IUPAC Name (Systematic)\",\n      \"name\":
+        \"2-[2,4-bis(chloranyl)phenoxy]-5-chloranyl-phenol\",\n      \"score\": 0\n
+        \   },\n    {\n      \"type\": \"Synonym\",\n      \"name\": \"Stri-Dex cleansing
+        bar (TN)\",\n      \"score\": 0\n    },\n    {\n      \"type\": \"Synonym\",\n
+        \     \"name\": \"Cloxifenol\",\n      \"score\": 0\n    }\n  ],\n  \"externalIds\":
+        \n  [\n    {\n      \"name\": \"BindingDB\",\n      \"value\": \"8726\",\n
+        \     \"url\": \"http://www.bindingdb.org/bind/chemsearch/marvin/MolStructure.jsp?monomerid=8726&entryid=1081\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-02\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"77488.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=77488\"\n    },\n
+        \   {\n      \"name\": \"MMDB\",\n      \"value\": \"87724.6\",\n      \"url\":
+        \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87724\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"24698180\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=24698180\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"86373.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86373\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136907267\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136907267\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS2270M06\",\n      \"url\": \"\"\n
+        \   },\n    {\n      \"name\": \"AK Scientific, Inc. (AKSCI)\",\n      \"value\":
+        \"69778\",\n      \"url\": \"http://www.aksci.com/item_detail.php?cat=69778\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"ST50826110\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Human Metabolome Database\",\n
+        \     \"value\": \"HMDB0061385\",\n      \"url\": \"http://www.hmdb.ca/metabolites/HMDB0061385\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"87723.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=87723\"\n
+        \   },\n    {\n      \"name\": \"PubChem CID\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"PubChem9026\",\n
+        \     \"url\": \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"117695801\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695801\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830483\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830483\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124767531\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124767531\"\n
+        \   },\n    {\n      \"name\": \"Chembo\",\n      \"value\": \"KB-197273\",\n
+        \     \"url\": \"http://www.chembopharma.com/search/?keyword=KB-197273\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"196106428\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=196106428\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"179113938\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=179113938\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56314344\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56314344\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"29589.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=29589\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89177.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223403966\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223403966\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"92519.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=92519\"\n
+        \   },\n    {\n      \"name\": \"ChemIDplus\",\n      \"value\": \"0003380345\",\n
+        \     \"url\": \"http://chem.sis.nlm.nih.gov/chemidplus/direct.jsp?result=advanced&regno=0003380345\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252091693\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252091693\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"13861.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=13861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57244094\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57244094\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135668580\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668580\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"91011813\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=91011813\"\n
+        \   },\n    {\n      \"name\": \"Angene Chemical\",\n      \"value\": \"5-Chloro-2-(2,4-dichlorophenoxy)phenol\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"10322303\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=10322303\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"105093-20-7\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Boerchem\",\n
+        \     \"value\": \"BC678270\",\n      \"url\": \"http://www.boerchemical.com/?product_39712.html\"\n
+        \   },\n    {\n      \"name\": \"Key Organics/BIONET\",\n      \"value\":
+        \"KS-5356\",\n      \"url\": \"http://www.keyorganics.net/bionet/catalog/product/view/id/516952\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"249832222\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=249832222\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"184558641\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=184558641\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14720377\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14720377\"\n
+        \   },\n    {\n      \"name\": \"SureChEMBL\",\n      \"value\": \"SCHEMBL3269\",\n
+        \     \"url\": \"https://www.surechembl.org/chemical/SCHEMBL3269\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"92308067\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92308067\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"D06226\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?dr:D06226\"\n    },\n    {\n      \"name\":
+        \"MMDB\",\n      \"value\": \"24741.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=24741\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87350665\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87350665\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"49387\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE1642\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"113584955\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584955\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"226395494\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=226395494\"\n
+        \   },\n    {\n      \"name\": \"chemicalize.org by ChemAxon\",\n      \"value\":
+        \"3314\",\n      \"url\": \"http://www.chemicalize.org/structure/#!mol=5-Chlor-2-%282%2C4-dichlorphenoxy%29-phenol&source=pubchem\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"48426058\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=48426058\"\n
+        \   },\n    {\n      \"name\": \"ChemFrog\",\n      \"value\": \"888-827-166\",\n
+        \     \"url\": \"http://www.chemfrog.com/getPSupply/RHMLL/\"\n    },\n    {\n
+        \     \"name\": \"Immune Epitope Database (IEDB)\",\n      \"value\": \"Epitope
+        ID:119683\",\n      \"url\": \"http://www.iedb.org/epId/119683\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"165354372\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=165354372\"\n
+        \   },\n    {\n      \"name\": \"Calbiochem\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-08\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"11752\",\n      \"value\":
+        \"BD20299\",\n      \"url\": \"http://www.bidepharmatech.com/en/goodsview_goodscode_BD20299.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134982808\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134982808\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-03\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"638158\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=638158\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"136375618\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=136375618\"\n
+        \   },\n    {\n      \"name\": \"\",\n      \"value\": \"ST2411924\",\n      \"url\":
+        \"http://www.syntree.com/3380-34-5\"\n    },\n    {\n      \"name\": \"ChEBI\",\n
+        \     \"value\": \"CHEBI:164200\",\n      \"url\": \"http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:164200\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250203727\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250203727\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335937\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"30100627\",\n      \"url\": \"http://www.chemmol.com/chemmol/30100627.html\"\n
+        \   },\n    {\n      \"name\": \"DiscoveryGate\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"https://www.discoverygate.com/interlink/search?KeyName=EXTREG&KeyValue=5564&Database=INDEX&Source=PUBCHEM\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152247191\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152247191\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144099663\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144099663\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90004.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90004\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126613105\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126613105\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11134.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11134\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892179\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892179\"\n
+        \   },\n    {\n      \"name\": \"Aurum Pharmatech LLC\",\n      \"value\":
+        \"M-6446\",\n      \"url\": \"http://www.Aurumpharmatech.com/Product/ProductDetails/M_6446\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"584337\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=584337\"\n
+        \   },\n    {\n      \"name\": \"Center for Chemical Genomics, University
+        of Michigan\",\n      \"value\": \"CCG-213459\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"118307780\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=118307780\"\n
+        \   },\n    {\n      \"name\": \"Chembase.cn\",\n      \"value\": \"6212\",\n
+        \     \"url\": \"http://www.chembase.cn/molecule-6212.html\"\n    },\n    {\n
+        \     \"name\": \"LeadScope\",\n      \"value\": \"LS-67854\",\n      \"url\":
+        \"http://www.leadscope.com/structure_search_results.php?ss_string=LS-67854\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"12209.11\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=12209\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"8153420\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=8153420\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250113382\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250113382\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170464936\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170464936\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87692612\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87692612\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"204386565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=204386565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135578505\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135578505\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou APIChem Technology\",\n      \"value\":
+        \"AC-10667\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"827598\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=827598\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14214\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14214\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252083456\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252083456\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695799\"\n
+        \   },\n    {\n      \"name\": \"EMD Millipore\",\n      \"value\": \"647950\",\n
+        \     \"url\": \"http://www.emdbiosciences.com/product/647950\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164187925\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164187925\"\n
+        \   },\n    {\n      \"name\": \"NextMove Software\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n
+        \     \"value\": \"AJ-08144\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57652433\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57652433\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160969637\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160969637\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"44010202\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/44010202.html\"\n    },\n
+        \   {\n      \"name\": \"Milwaukee Institute for Drug Discovery\",\n      \"value\":
+        \"NC00516\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"47207884\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47207884\"\n
+        \   },\n    {\n      \"name\": \"ChemMol\",\n      \"value\": \"99161097\",\n
+        \     \"url\": \"http://www.chemmol.com/chemmol/99161097.html\"\n    },\n
+        \   {\n      \"name\": \"Ambinter\",\n      \"value\": \"SBB058565\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"5664285\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=5664285\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"114065.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=114065\"\n
+        \   },\n    {\n      \"name\": \"Tractus\",\n      \"value\": \"RTR-014090\",\n
+        \     \"url\": \"http://www.tractuschem.com/productshow/RTR-014090.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124766493\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124766493\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126522651\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126522651\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252126888\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252126888\"\n
+        \   },\n    {\n      \"name\": \"CAPOT\",\n      \"value\": \"9026\",\n      \"url\":
+        \"http://www.capotchem.com/en/9026.htm\"\n    },\n    {\n      \"name\": \"Anward\",\n
+        \     \"value\": \"ANW-42338\",\n      \"url\": \"http://www.anward.com/pro_result/29973\"\n
+        \   },\n    {\n      \"name\": \"TimTec\",\n      \"value\": \"SBB058565\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening
+        Facility, Harvard Medical School\",\n      \"value\": \"HMS2093L17\",\n      \"url\":
+        \"http://iccb.med.harvard.edu/screening/compound_libraries/bioactives_microsource1.htm\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"47193732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=47193732\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-04\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"EPA Substance Registry
+        Services\",\n      \"value\": \"115139\",\n      \"url\": \"http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=SRSITN&p_value=115139\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"3380-34-5\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"137003021\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=137003021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"117695803\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=117695803\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57389809\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57389809\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103905760\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905760\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99401.5\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99401\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143433021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143433021\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"123938.12\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=123938\"\n
+        \   },\n    {\n      \"name\": \"BioCyc\",\n      \"value\": \"CPD0-1227\",\n
+        \     \"url\": \"http://biocyc.org/META/NEW-IMAGE?type=COMPOUND&object=CPD0-1227\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"208265074\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=208265074\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103222736\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103222736\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"125022.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=125022\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90003.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90003\"\n
+        \   },\n    {\n      \"name\": \"ChemDB\",\n      \"value\": \"3968915\",\n
+        \     \"url\": \"http://cdb.ics.uci.edu/CHEMDB/Web/cgibin/ChemicalDetailWeb.py?chemical_id=3968915\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49674565\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49674565\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"211786863\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=211786863\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"7890716\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=7890716\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"43585.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43585\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"175442272\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175442272\"\n
+        \   },\n    {\n      \"name\": \"Mcule\",\n      \"value\": \"MCULE-2614621397\",\n
+        \     \"url\": \"https://mcule.com/MCULE-2614621397\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"172080639\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172080639\"\n
+        \   },\n    {\n      \"name\": \"SGCOxCompounds\",\n      \"value\": \"S00100\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"IS Chemical Technology\",\n
+        \     \"value\": \"I01-2897\",\n      \"url\": \"http://www.ispharm.com/product/I01-2897.html\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126632200\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126632200\"\n
+        \   },\n    {\n      \"name\": \"ChemTik\",\n      \"value\": \"CTK3J8301\",\n
+        \     \"url\": \"http://www.chemtik.com/pro_result/398301/\"\n    },\n    {\n
+        \     \"name\": \"MMDB\",\n      \"value\": \"65341.6\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=65341\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"250180394\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=250180394\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"152137732\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152137732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"251886846\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=251886846\"\n
+        \   },\n    {\n      \"name\": \"SCRIPDB\",\n      \"value\": \"US20120010284A1-20120112-C00025_9\",\n
+        \     \"url\": \"http://dcv.uhnres.utoronto.ca/SCRIPDB/results/?patentid=US20120010284A1-20120112-C00025_9\"\n
+        \   },\n    {\n      \"name\": \"Shanghai Institute of Organic Chemistry\",\n
+        \     \"value\": \"3p9t\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=3p9t\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DNC001513\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DNC001513\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"126648856\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=126648856\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260157\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260157\"\n
+        \   },\n    {\n      \"name\": \"TCI (Tokyo Chemical Industry)\",\n      \"value\":
+        \"T1872\",\n      \"url\": \"\"\n    },\n    {\n      \"name\": \"DrugBank\",\n
+        \     \"value\": \"DB08604\",\n      \"url\": \"http://www.drugbank.ca/drugs/DB08604\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"151989799\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=151989799\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57322843\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57322843\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"152138388\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=152138388\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134338639\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134338639\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"830851\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=830851\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"135684207\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135684207\"\n
+        \   },\n    {\n      \"name\": \"3B_SCI\",\n      \"value\": \"3B3-011899\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"11109466\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=11109466\"\n
+        \   },\n    {\n      \"name\": \"HDH Pharma\",\n      \"value\": \"IN1424\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"86123.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=86123\"\n
+        \   },\n    {\n      \"name\": \"Life Chemicals\",\n      \"value\": \"F2173-0825\",\n
+        \     \"url\": \"http://lifechemicals.emolecules.com\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"223774642\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223774642\"\n
+        \   },\n    {\n      \"name\": \"CAS\",\n      \"value\": \"88032-08-0\",\n
+        \     \"url\": \"http://www.cas.org/\"\n    },\n    {\n      \"name\": \"Pubchem
+        SID\",\n      \"value\": \"92710097\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=92710097\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"125348302\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=125348302\"\n
+        \   },\n    {\n      \"name\": \"FINETECH\",\n      \"value\": \"FT-0609773\",\n
+        \     \"url\": \"http://www.finetechnology-ind.com/product_detail.shtml?catalogNo=FT-0609773\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11627.3\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11627\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104309596\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104309596\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144205201\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144205201\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_400079\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"129676338\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=129676338\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26754498\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26754498\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"121362549\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=121362549\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49903859\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49903859\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"80407.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=80407\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"164794929\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=164794929\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"50109854\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=50109854\"\n
+        \   },\n    {\n      \"name\": \"Sigma-Aldrich\",\n      \"value\": \"72779_SIGMA\",\n
+        \     \"url\": \"http://www.sigmaaldrich.com/catalog/search/ProductDetail/SIGMA/72779?cm_mmc=affiliate-_-PubChem-_-product-_-link\"\n
+        \   },\n    {\n      \"name\": \"Hangzhou Trylead Chemical Technology\",\n
+        \     \"value\": \"TL8002539\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"135668588\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=135668588\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99453849\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99453849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"14922470\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=14922470\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"57260158\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=57260158\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"37767\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"NIH Clinical Collection\",\n
+        \     \"value\": \"SAM002554907\",\n      \"url\": \"\"\n    },\n    {\n      \"name\":
+        \"Tractus\",\n      \"value\": \"TR-014090\",\n      \"url\": \"\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"56313852\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=56313852\"\n
+        \   },\n    {\n      \"name\": \"Oakwood Products\",\n      \"value\": \"079476\",\n
+        \     \"url\": \"http://www.oakwoodchemical.com/ProductsList.aspx?CategoryID=-2&txtSearch=64650&ExtHyperLink=1\"\n
+        \   },\n    {\n      \"name\": \"Collaborative Drug Discovery, Inc.\",\n      \"value\":
+        \"2304\",\n      \"url\": \"https://app.collaborativedrug.com/public/structures/2304\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"186020461\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=186020461\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"ZB000507\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"\",\n      \"value\": \"50-7869\",\n      \"url\": \"http://www.greenchempharm.com/\"\n
+        \   },\n    {\n      \"name\": \"DTP/NCI\",\n      \"value\": \"759151\",\n
+        \     \"url\": \"http://dtp.nci.nih.gov/dtpstandard/servlet/dwindex?searchtype=NSC&outputformat=html&searchlist=759151\"\n
+        \   },\n    {\n      \"name\": \"ChEMBL\",\n      \"value\": \"CHEMBL849\",\n
+        \     \"url\": \"https://www.ebi.ac.uk/chembldb/index.php/compound/inspect/CHEMBL849\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"176324148\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=176324148\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"241151993\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241151993\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"26759661\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=26759661\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170481145\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170481145\"\n
+        \   },\n    {\n      \"name\": \"Broad Institute\",\n      \"value\": \"BRD-K41731458-001-09-4\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"223485437\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223485437\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49968902\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49968902\"\n
+        \   },\n    {\n      \"name\": \"ABI Chem\",\n      \"value\": \"AC1L1KMN\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"99084008\",\n      \"url\": \"http://www.chemmol.com/chemmol/99084008.html\"\n
+        \   },\n    {\n      \"name\": \"MolPort\",\n      \"value\": \"MolPort-003-666-702\",\n
+        \     \"url\": \"https://www.molport.com/shop/molecule-link/MolPort-003-666-702\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"104170014\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=104170014\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174006648\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174006648\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"160809838\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=160809838\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"836967\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=836967\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"45855.6\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=45855\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"172848469\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=172848469\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124813021\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124813021\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223519140\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223519140\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144214040\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144214040\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"174477329\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=174477329\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001066347\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"163812839\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163812839\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"38016.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=38016\"\n
+        \   },\n    {\n      \"name\": \"King Scientific\",\n      \"value\": \"KSC498G0D\",\n
+        \     \"url\": \"http://www.kingscientific.com/pro_result/8687/\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"252039861\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=252039861\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"162174892\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162174892\"\n
+        \   },\n    {\n      \"name\": \"Ark Pharm, Inc.\",\n      \"value\": \"AK-73001\",\n
+        \     \"url\": \"http://www.arkpharminc.com/web/products-detail.html?catalogno=AK-73001\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"99398.10\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=99398\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144075889\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144075889\"\n
+        \   },\n    {\n      \"name\": \"A&J Pharmtech CO., LTD.\",\n      \"value\":
+        \"CJ-00083\",\n      \"url\": \"http://www.ajpharmtech.com/\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"241074904\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=241074904\"\n    },\n
+        \   {\n      \"name\": \"IBM\",\n      \"value\": \"96566AD92878ECA0254CFD7818088D7A\",\n
+        \     \"url\": \"http://www.ibm.com/gbs/nih/?sid=96566AD92878ECA0254CFD7818088D7A&ik=XEFQLINVKFYRCS-UHFFFAOYSA-N\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"99445075\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=99445075\"\n
+        \   },\n    {\n      \"name\": \"Tox21\",\n      \"value\": \"NCGC00159417-05\",\n
+        \     \"url\": \"https://tripod.nih.gov/tox21/samples/Tox21_111648_1\"\n    },\n
+        \   {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85172710\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85172710\"\n
+        \   },\n    {\n      \"name\": \"Therapeutic Targets Database\",\n      \"value\":
+        \"DAP001435\",\n      \"url\": \"http://bidd.nus.edu.sg/group/cjttd/ZFTTDDRUG.asp?ID=DAP001435\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892178\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892178\"\n
+        \   },\n    {\n      \"name\": \"NovoSeek\",\n      \"value\": \"5564\",\n
+        \     \"url\": \"http://www.novoseek.com/AccessPoint.action?corpus=MEDLINE&externalDBId=cid%3d5564&DBName=pubchem&actionName=search&bioType=drug\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"223454576\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=223454576\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"90005.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=90005\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"87577595\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=87577595\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-06\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"MMDB\",\n      \"value\":
+        \"43581.4\",\n      \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=43581\"\n
+        \   },\n    {\n      \"name\": \"labseeker\",\n      \"value\": \"SC-16588\",\n
+        \     \"url\": \"http://www.labseeker.com/goods.php?id=22337\"\n    },\n    {\n
+        \     \"name\": \"Pubchem SID\",\n      \"value\": \"103905763\",\n      \"url\":
+        \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103905763\"\n    },\n
+        \   {\n      \"name\": \"Berrchem\",\n      \"value\": \"BR-73001\",\n      \"url\":
+        \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"49832484\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=49832484\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"134340679\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=134340679\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"124892177\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=124892177\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"143858045\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=143858045\"\n
+        \   },\n    {\n      \"name\": \"NCGC\",\n      \"value\": \"NCGC00159417-07\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"ChemMol\",\n      \"value\":
+        \"1034685\",\n      \"url\": \"http://www.chemmol.com/chemmol/1034685.html\"\n
+        \   },\n    {\n      \"name\": \"AKos Consulting & Solutions\",\n      \"value\":
+        \"AKOS015850380\",\n      \"url\": \"http://akoscompounds.de/catalogue/akossamplesretrieval.php?IDNUMBERS=AKOS015850380\"\n
+        \   },\n    {\n      \"name\": \"KEGG\",\n      \"value\": \"C12059\",\n      \"url\":
+        \"http://www.genome.jp/dbget-bin/www_bget?cpd:C12059\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"175611134\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=175611134\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"48839\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE8861\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"22126.7\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=22126\"\n
+        \   },\n    {\n      \"name\": \"AmicBase - Antimicrobial Activities\",\n
+        \     \"value\": \"6191\",\n      \"url\": \"http://www.manetec-52.de/apps/amicbase_drugs-online/base.nsf/WebMain4?SearchView&Query=%28%5BDocType%5D=%22DataFormular%22%29%20AND%20%28%5BLine_1_S%5D=%28%226191*%22%29%29&SearchWV=FALSE&SearchOrder=4&SearchMax=0&Count=50&Start=1&SearchBasis=extern2&FromView=WebMain4\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071986\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071986\"\n
+        \   },\n    {\n      \"name\": \"SMID\",\n      \"value\": \"TCL\",\n      \"url\":
+        \"http://smid.blueprint.org/SMInfo.php?hetname=TCL\"\n    },\n    {\n      \"name\":
+        \"Pubchem SID\",\n      \"value\": \"162766619\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=162766619\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"131311043\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=131311043\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"144071804\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=144071804\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001335938\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Shanghai Institute of
+        Organic Chemistry\",\n      \"value\": \"1nhg\",\n      \"url\": \"http://www.pdbbind-cn.org/quickpdb.asp?quickpdb=1nhg\"\n
+        \   },\n    {\n      \"name\": \"MLSMR\",\n      \"value\": \"MLS001074876\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"113584959\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=113584959\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"85256706\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=85256706\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"11303.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=11303\"\n
+        \   },\n    {\n      \"name\": \"EPA DSSTox\",\n      \"value\": \"40328\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Thomson Pharma\",\n
+        \     \"value\": \"00026732\",\n      \"url\": \"http://www.thomson-pharma.com/report/chemistry?ch=TS00026732\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"53800864\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=53800864\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"103022876\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=103022876\"\n
+        \   },\n    {\n      \"name\": \"MMDB\",\n      \"value\": \"89179.4\",\n
+        \     \"url\": \"http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=89179\"\n
+        \   },\n    {\n      \"name\": \"Amadis Chemical\",\n      \"value\": \"A821950\",\n
+        \     \"url\": \"http://www.amadischem.com/en-US/ProductDetail.aspx?catalog=A821950\"\n
+        \   },\n    {\n      \"name\": \"NIST\",\n      \"value\": \"XEFQLINVKFYRCS-UHFFFAOYSA-N\",\n
+        \     \"url\": \"\"\n    },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\":
+        \"138139326\",\n      \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=138139326\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"170483649\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=170483649\"\n
+        \   },\n    {\n      \"name\": \"ICCB-Longwood/NSRB Screening Facility, Harvard
+        Medical School\",\n      \"value\": \"HMS3259K19\",\n      \"url\": \"http://iccb.med.harvard.edu/screening/compound_libraries/ncc2.htm\"\n
+        \   },\n    {\n      \"name\": \"NIAID\",\n      \"value\": \"095068\",\n
+        \     \"url\": \"http://chemdb.niaid.nih.gov/CompoundDetails.aspx?AIDSNO=095068\"\n
+        \   },\n    {\n      \"name\": \"Pubchem SID\",\n      \"value\": \"163687196\",\n
+        \     \"url\": \"https://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?sid=163687196\"\n
+        \   }\n  ]\n}"
+  recorded_at: 2023-08-03 19:57:54 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0
+- request:
+    method: get
+    uri: http://cts.fiehnlab.ucdavis.edu/service/conversion/fromValues
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      Content-Type: ''
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Thu, 03 Aug 2023 19:57:54 GMT
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: |2-
+
+        [
+          "BioCyc",
+          "CAS",
+          "ChEBI",
+          "Chemical Name",
+          "Human Metabolome Database",
+          "InChIKey",
+          "KEGG",
+          "LMSD",
+          "LipidMAPS",
+          "PubChem CID",
+          "SMILES",
+          "Pubchem SID",
+          "ChemSpider",
+          "ChemDB",
+          "ChEMBL",
+          "ChemBank",
+          "ZINC",
+          "Broad Institute",
+          "The Scripps Research Institute Molecular Screening Center",
+          "DrugBank",
+          "MMDB",
+          "ChemMol",
+          "NIAID",
+          "Southern Research Institute",
+          "NIH Clinical Collection",
+          "Comparative Toxicogenomics Database",
+          "MolPort",
+          "SMID",
+          "ChemBridge",
+          "GlaxoSmithKline (GSK)",
+          "NINDS Approved Drug Screening Program",
+          "NIST",
+          "SCRIPDB",
+          "Southern Research Specialized Biocontainment Screening Center",
+          "TimTec",
+          "Tox21",
+          "Web of Science",
+          "ABI Chem",
+          "Center for Chemical Genomics, University of Michigan",
+          "ChemIDplus",
+          "Sigma-Aldrich",
+          "ASINEX",
+          "ChemBlock",
+          "DiscoveryGate",
+          "Specs",
+          "Ambinter",
+          "Emory University Molecular Libraries Screening Center",
+          "MLSMR",
+          "Vitas-M Laboratory",
+          "AAA Chemistry",
+          "ChemFrog",
+          "Isoprenoids",
+          "NCGC",
+          "Acesobio",
+          "ALDRICH",
+          "Ambit Biosciences",
+          "CLRI (CSIR)",
+          "InFarmatik",
+          "IS Chemical Technology",
+          "MOLI",
+          "SIGMA",
+          "Tetrahedron Scientific Inc",
+          "Thomson Pharma",
+          "ABBLIS Chemicals",
+          "Abbott Labs",
+          "AbMole Bioscience",
+          "Achemica",
+          "Acorn PharmaTech",
+          "Active Biopharma",
+          "Adooq BioScience",
+          "AKos Consulting & Solutions",
+          "AK Scientific, Inc. (AKSCI)",
+          "Alagar Yadav, Karpagam University",
+          "Alinda Chemical",
+          "Alsachim",
+          "Amadis Chemical",
+          "Amatye",
+          "AmicBase - Antimicrobial Activities",
+          "Angene Chemical",
+          "Angene International",
+          "Ark Pharm, Inc.",
+          "BioChemPartner",
+          "BroadPharm",
+          "Chembase.cn",
+          "Chembo",
+          "chemicalize.org by ChemAxon",
+          "Fragmenta",
+          "Anitha, Department of Bioinformatics, Karpagam University",
+          "Annker Organics",
+          "Anward",
+          "Apeiron Synthesis",
+          "ApexBio Technology",
+          "Apexmol",
+          "Aromsyn catalogue",
+          "Aronis",
+          "Aurora Fine Chemicals LLC",
+          "Aurum Pharmatech LLC",
+          "Avanti Polar Lipids",
+          "Beijing Advanced Technology Co, Ltd",
+          "Bertin Pharma",
+          "Bhaskar Lab, Department of Zoology, Sri Venkateswara University",
+          "BIDD",
+          "BIND",
+          "BindingDB",
+          "Biological Magnetic Resonance Data Bank (BMRB)",
+          "Bioprocess Technology Lab, Department of Microbiology, Bharathidasan University",
+          "Biosynth",
+          "Burnham Center for Chemical Genomics",
+          "Calbiochem",
+          "Cambridge Crystallographic Data Centre",
+          "CAPOT",
+          "Cayman Chemical",
+          "CC_PMLSC",
+          "ChemExper Chemical Directory",
+          "Chemical Biology Department, Max Planck Institute of Molecular Physiology",
+          "ChemScene",
+          "ChemSynthesis",
+          "ChemTik",
+          "Chiralblock Biosciences",
+          "Circadian Research, Kay Laboratory, University of California at San Diego (UCSD)",
+          "CMLD-BU",
+          "Columbia University Molecular Screening Center",
+          "Creasyn Finechem",
+          "Department of Pharmacy, LMU",
+          "DTP/NCI",
+          "EDASA Scientific Compounds June 2013",
+          "EMD Biosciences",
+          "Enamine",
+          "Ennopharm",
+          "EPA DSSTox",
+          "Excenen Pharmatech",
+          "Exchemistry",
+          "FINETECH",
+          "Finley and King Labs, Harvard Medical School",
+          "FLUKA",
+          "ForeChem",
+          "Georganics",
+          "GLIDA, GPCR-Ligand Database",
+          "GNF / Scripps Winzeler lab",
+          "Golm Metabolome Database (GMD), Max Planck Institute of Molecular Plant Physiology",
+          "Hangzhou APIChem Technology",
+          "Hangzhou Trylead Chemical Technology",
+          "HDH Pharma",
+          "HUMGENEX",
+          "IBCH RAS",
+          "IBM",
+          "ICCB-Longwood/NSRB Screening Facility, Harvard Medical School",
+          "Immunology Lab, Department of Biotechnology, Calicut University",
+          "Inhibitor 2",
+          "Insect Molecular Biology Lab, Department of Environmental Biotechnology, Bharathidasan University",
+          "iThemba Pharmaceuticals",
+          "IUPHAR-DB",
+          "Jamson Pharmachem Technology",
+          "Japan Chemical Substance Dictionary (Nikkaji)",
+          "Johns Hopkins Ion Channel Center",
+          "Kingston Chemistry",
+          "KUMGM",
+          "LeadScope",
+          "MedChemexpress MCE",
+          "MICAD",
+          "MIC Scientific",
+          "Milwaukee Institute for Drug Discovery",
+          "Molecular Libraries Program, Specialized Chemistry Center, University of Kansas",
+          "MP Biomedicals",
+          "MTDP",
+          "Nanjing Pharmaceutical Factory",
+          "Nantong Baihua Bio-Pharmaceutical Co., Ltd",
+          "Nature Chemical Biology",
+          "Nature Chemistry",
+          "Nature Communications",
+          "NIST Chemistry WebBook",
+          "Nitric Oxide Research, National Cancer Institute (NCI)",
+          "NMMLSC",
+          "NMRShiftDB",
+          "NovoSeek",
+          "Oakwood Products",
+          "ORST SMALL MOLECULE SCREENING CENTER",
+          "P3 BioSystems",
+          "PANACHE",
+          "Paul Baures",
+          "PCMD",
+          "PDSP",
+          "PENN-ABS",
+          "PennChem-GAM",
+          "PFC",
+          "P.Ravikumar, M.Jeyam and G.Shalini. Biochematics Division, Bharathiar University",
+          "priyadharshini sabarathinam angayarkanni murugesh palaniswamy",
+          "Prous Science Drugs of the Future",
+          "Rangan Lab, Department of Biotechnology, IIT Guwahati",
+          "R&D Chemicals",
+          "R.Sathishkumar, Phytomatics Laboratory, Department of Bioinformatics, Bharathiar University",
+          "RSChem, LLC",
+          "SASTRA University, Quorum sensing and Peptidomimetics Laboratory",
+          "Selleckbio",
+          "Selleck Chemicals",
+          "SGCOxCompounds",
+          "SGCStoCompounds",
+          "S.GURUDEEBAN, T.RAMANATHAN & K.SATYAVANI, Marine Medicinal Plant Biotechnology Laboratory, Faculty of Marine Sciences, Annamalai Universtiy",
+          "Shanghai Institute of Organic Chemistry",
+          "Shanghai Sinofluoro Scientific Company",
+          "SLING Consortium",
+          "SRMLSC",
+          "Structural Genomics Consortium",
+          "SureChem",
+          "SYNCHEM OHG",
+          "Syntechem",
+          "TCI (Tokyo Chemical Industry)",
+          "ten Dijke Lab, Leiden University Medical Center",
+          "Therapeutic Targets Database",
+          "Total TOSLab Building-Blocks",
+          "True PharmaChem",
+          "Tyger Scientific",
+          "UCLA Molecular Screening Shared Resource",
+          "UM-BBD",
+          "UniCarbKB",
+          "University of Pittsburgh Molecular Library Screening Center",
+          "UPCMLD",
+          "Vanderbilt Screening Center for GPCRs, Ion Channels and Transporters",
+          "Vanderbilt Specialized Chemistry Center",
+          "Vanderbilt University Medical Center",
+          "VIT University",
+          "Watec Laboratories",
+          "Watson International Ltd",
+          "xPharm",
+          "Zancheng Functional Chemicals",
+          "zealing chemical"
+        ]
+  recorded_at: 2023-08-03 19:57:54 GMT
+  recorded_with: vcr/1.2.0, webmockr/0.9.0

--- a/tests/testthat/test-chebi.R
+++ b/tests/testthat/test-chebi.R
@@ -1,12 +1,14 @@
 up <- ping_service("chebi")
 test_that("examples in the article are unchanged", {
-  skip_on_cran()
-  skip_if_not(up, "CHEBI service is down")
+  # skip_on_cran()
+  # skip_if_not(up, "CHEBI service is down")
 
   utils::data("lc50", package = "webchem")
   cas_rns <- lc50[order(lc50$value)[1:3], "cas"]
-  chebiids <- get_chebiid(cas_rns)
-  comp <- chebi_comp_entity(chebiids$chebiid)
+  vcr::use_cassette("chebi-article", {
+    chebiids <- get_chebiid(cas_rns)
+    comp <- chebi_comp_entity(chebiids$chebiid)
+  })
   pars <- lapply(comp, function(x) {
     with(x, parents[parents$type == "has role", ])
   })
@@ -26,12 +28,14 @@ test_that("examples in the article are unchanged", {
 })
 
 test_that("chebi returns correct results", {
-  skip_on_cran()
-  skip_if_not(up, "CHEBI service is down")
-  a <- get_chebiid("Glyphosate", from = "all")
-  b <- get_chebiid(c("triclosan", "glyphosate", "balloon", NA))
-  A <- chebi_comp_entity("CHEBI:27744")
-  B <- chebi_comp_entity("27732")
+  # skip_on_cran()
+  # skip_if_not(up, "CHEBI service is down")
+  vcr::use_cassette("chebi-correct", {
+    a <- get_chebiid("Glyphosate", from = "all")
+    b <- get_chebiid(c("triclosan", "glyphosate", "balloon", NA))
+    A <- chebi_comp_entity("CHEBI:27744")
+    B <- chebi_comp_entity("27732")
+  })
 
   expect_s3_class(a, "data.frame")
   expect_s3_class(b, "data.frame")
@@ -47,8 +51,9 @@ test_that("chebi returns correct results", {
 })
 
 test_that("get_chebiid() handles special characters in SMILES",{
-  skip_on_cran()
-  skip_if_not(up, "CHEBI service is down")
-
-  expect_equal(get_chebiid("C#C", from = "smiles")$chebiid, "CHEBI:27518")
+  # skip_on_cran()
+  # skip_if_not(up, "CHEBI service is down")
+  vcr::use_cassette("chebi-smiles", {
+    expect_equal(get_chebiid("C#C", from = "smiles")$chebiid, "CHEBI:27518")
+  })
 })

--- a/tests/testthat/test-chemspider.R
+++ b/tests/testthat/test-chemspider.R
@@ -19,7 +19,7 @@ test_that("examples in the article are unchanged", {
 
 test_that("cs_check_key() can find API key in my local .Renviron", {
 
-    expect_type(cs_check_key(), "character")
+  expect_type(cs_check_key(), "character")
 })
 
 test_that("cs_datasources()", {
@@ -76,18 +76,18 @@ test_that("get_csid()", {
     # get_csid() works with cs_control()
     c1 <- utils::head(get_csid("iron oxide", from = "name", order_by = "recordId"))
     c3 <- utils::head(get_csid("iron oxide", from = "name",
-                        order_by = "molecularWeight"))
+                               order_by = "molecularWeight"))
     c4 <- utils::head(get_csid("C6H12O6", from = "formula",
-                        order_by = "referenceCount",
-                        order_direction = "descending"))
+                               order_by = "referenceCount",
+                               order_direction = "descending"))
     c5 <- utils::head(get_csid("C6H12O6", from = "formula", order_by = "dataSourceCount",
-                        order_direction = "descending"))
+                               order_direction = "descending"))
     c6 <- utils::head(get_csid("C6H12O6", from = "formula", order_by = "pubMedCount",
-                        order_direction = "descending"))
+                               order_direction = "descending"))
     c7 <- utils::head(get_csid("C6H12O6", from = "formula", order_by = "rscCount",
-                        order_direction = "descending"))
+                               order_direction = "descending"))
     c8 <- utils::head(get_csid("iron oxide", from = "name", order_by = "molecularWeight",
-                        order_direction = "descending"))
+                               order_direction = "descending"))
 
     # get_csid() handles special characters in SMILES
     d1 <- get_csid("C#C", from = "smiles")
@@ -100,7 +100,7 @@ test_that("get_csid()", {
 
     # get_csid() can query inchikeys
     g1 <- get_csid("QTBSBXVTEAMEQO-UHFFFAOYSA-N", from = "inchikey")
-    })
+  })
 
   # get_csid() works with defaults
   expect_s3_class(a, "data.frame")
@@ -231,11 +231,12 @@ test_that("cs_compinfo()", {
   expect_equal(dim(b), c(2, 18))
 })
 
-#need to figure out how to test images with vcr
-#test_that("cs_img()", {
+#TODO: need to figure out how to test images with vcr
+test_that("cs_img()", {
+  skip_on_cran()
+  skip_if_not(ping_service("cs"), "Chemspider is down")
+  imgs <- cs_img(c(682, 5363, "balloon", NA), dir = tempdir())
 
-  #imgs <- cs_img(c(682, 5363, "balloon", NA), dir = tempdir())
-
-  #expect_true(file.exists(paste0(tempdir(), "/", "682.png")))
-  #expect_true(file.exists(paste0(tempdir(), "/", "5363.png")))
-#})
+  expect_true(file.exists(paste0(tempdir(), "/", "682.png")))
+  expect_true(file.exists(paste0(tempdir(), "/", "5363.png")))
+})

--- a/tests/testthat/test-cir.R
+++ b/tests/testthat/test-cir.R
@@ -1,26 +1,23 @@
 up <- ping_service("cir")
 test_that("cir_query()", {
-  # skip_on_cran()
-  # skip_if_not(up, "CIR server is down")
-  vcr::use_cassette("cir_query", {
-    expect_equal(cir_query('Triclosan', 'mw')$mw[1], 289.5451)
-    expect_equal(cir_query('xxxxxxx', 'mw')$mw[1], NA)
-    expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number')$stdinchikey[1],
-                 "InChIKey=XEFQLINVKFYRCS-UHFFFAOYSA-N")
-    expect_true(nrow(cir_query('Triclosan', 'cas')) > 1)
-    expect_true(nrow(cir_query('Triclosan', 'cas', match = "first")) == 1)
-    expect_true(nrow(cir_query(c('Triclosan', 'Aspirin'), 'cas', match = "first")) == 2)
+  skip_on_cran()
+  skip_if_not(up, "CIR server is down")
+  expect_equal(cir_query('Triclosan', 'mw')$mw[1], 289.5451)
+  expect_equal(cir_query('xxxxxxx', 'mw')$mw[1], NA)
+  expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number')$stdinchikey[1],
+               "InChIKey=XEFQLINVKFYRCS-UHFFFAOYSA-N")
+  expect_true(nrow(cir_query('Triclosan', 'cas')) > 1)
+  expect_true(nrow(cir_query('Triclosan', 'cas', match = "first")) == 1)
+  expect_true(nrow(cir_query(c('Triclosan', 'Aspirin'), 'cas', match = "first")) == 2)
 
-    expect_equal(cir_query('acetic acid', 'mw', match = "first"),
-                 tibble(query = "acetic acid", mw = 60.0524))
-  })
+  expect_equal(cir_query('acetic acid', 'mw', match = "first"),
+               tibble(query = "acetic acid", mw = 60.0524))
 
 })
 
 test_that("cir_query() handles special characters in SMILES", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
-
   expect_equal(cir_query("C#C", representation = "inchikey")$inchikey,
                "InChIKey=HSFWRNGVRCDJHI-UHFFFAOYNA-N")
 })
@@ -28,7 +25,6 @@ test_that("cir_query() handles special characters in SMILES", {
 test_that("cir_query() handles NA queries and queries that return NA", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
-
   expect_identical(
     cir_query(c("Triclosan", "pumpkin", NA), representation = "cas",match = "first"),
     tibble(query = c("Triclosan", "pumpkin", NA_character_),

--- a/tests/testthat/test-cir.R
+++ b/tests/testthat/test-cir.R
@@ -1,26 +1,20 @@
 up <- ping_service("cir")
 test_that("cir_query()", {
-  skip_on_cran()
-  skip_if_not(up, "CIR server is down")
+  # skip_on_cran()
+  # skip_if_not(up, "CIR server is down")
+  vcr::use_cassette("cir_query", {
+    expect_equal(cir_query('Triclosan', 'mw')$mw[1], 289.5451)
+    expect_equal(cir_query('xxxxxxx', 'mw')$mw[1], NA)
+    expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number')$stdinchikey[1],
+                 "InChIKey=XEFQLINVKFYRCS-UHFFFAOYSA-N")
+    expect_true(nrow(cir_query('Triclosan', 'cas')) > 1)
+    expect_true(nrow(cir_query('Triclosan', 'cas', match = "first")) == 1)
+    expect_true(nrow(cir_query(c('Triclosan', 'Aspirin'), 'cas', match = "first")) == 2)
 
-  expect_equal(cir_query('Triclosan', 'mw')$mw[1], 289.5451)
-  expect_equal(cir_query('xxxxxxx', 'mw')$mw[1], NA)
-  expect_equal(cir_query("3380-34-5", 'stdinchikey', resolver = 'cas_number')$stdinchikey[1],
-            "InChIKey=XEFQLINVKFYRCS-UHFFFAOYSA-N")
-  expect_true(nrow(cir_query('Triclosan', 'cas')) > 1)
-  expect_true(nrow(cir_query('Triclosan', 'cas', match = "first")) == 1)
-  expect_true(nrow(cir_query(c('Triclosan', 'Aspirin'), 'cas', match = "first")) == 2)
+    expect_equal(cir_query('acetic acid', 'mw', match = "first"),
+                 tibble(query = "acetic acid", mw = 60.0524))
+  })
 
-  expect_equal(cir_query('acetic acid', 'mw', match = "first"),
-               tibble(query = "acetic acid", mw = 60.0524))
-
-})
-
-test_that("cir_query() doesn't mistake NA for sodium", {
-  skip_on_cran()
-  skip_if_not(up, "CIR server is down")
-
-  expect_true(is.na(cir_query(as.character(NA), 'cas')$cas))
 })
 
 test_that("cir_query() handles special characters in SMILES", {

--- a/tests/testthat/test-cts.R
+++ b/tests/testthat/test-cts.R
@@ -1,16 +1,16 @@
 up <- ping_service("cts")
 test_that("cts_compinfo()", {
-  skip_on_cran()
+  # skip_on_cran()
+  # skip_if_not(up, "CTS service down")
+  vcr::use_cassette("cts_compinfo", {
+    expect_true(is.na(cts_compinfo("xxx")))
 
-  skip_if_not(up, "CTS service down")
-
-  expect_true(is.na(cts_compinfo("xxx")))
-
-  o1 <- suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-N"))
-  o2 <- suppressWarnings(cts_compinfo(c("XEFQLINVKFYRCS-UHFFFAOYSA-N",
-                                        "XEFQLINVKFYRCS-UHFFFAOYSA-X")))
-  expect_equal(suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-X"))[[1]], NA)
-  expect_true(is.na(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-X")))
+    o1 <- suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-N"))
+    o2 <- suppressWarnings(cts_compinfo(c("XEFQLINVKFYRCS-UHFFFAOYSA-N",
+                                          "XEFQLINVKFYRCS-UHFFFAOYSA-X")))
+    expect_equal(suppressWarnings(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-X"))[[1]], NA)
+    expect_true(is.na(cts_compinfo("XEFQLINVKFYRCS-UHFFFAOYSA-X")))
+  })
   expect_length(o1[[1]], 11)
   expect_equal(round(o1[[1]][["molweight"]], 3), 289.542)
   expect_length(o2, 2)
@@ -19,36 +19,38 @@ test_that("cts_compinfo()", {
 
 
 test_that("cts_convert()", {
-  skip_on_cran()
-  skip_if_not(up, "CTS service down")
+  # skip_on_cran()
+  # skip_if_not(up, "CTS service down")
 
   comp <- c('Triclosan', 'Hexane')
-  expect_error(cts_convert(comp, c('Chemical Name', 'CAS'), 'CAS'))
-  expect_error(cts_convert('Triclosan', 'CAS'))
-  expect_true(is.na(cts_convert('xxxx', 'Chemical Name', 'inchikey')))
+  vcr::use_cassette("cts_convert", {
+    expect_error(cts_convert(comp, c('Chemical Name', 'CAS'), 'CAS'))
+    expect_error(cts_convert('Triclosan', 'CAS'))
+    expect_true(is.na(cts_convert('xxxx', 'Chemical Name', 'inchikey')))
 
-  o1 <- cts_convert(comp, 'Chemical Name', 'inchikey', match = "first")
-  expect_length(o1, 2)
+    o1 <- cts_convert(comp, 'Chemical Name', 'inchikey', match = "first")
+    expect_length(o1, 2)
 
-  expect_equal(o1[[1]], 'XEFQLINVKFYRCS-UHFFFAOYSA-N')
+    expect_equal(o1[[1]], 'XEFQLINVKFYRCS-UHFFFAOYSA-N')
 
-  expect_equal(cts_convert("triclosan", "chemical name", "inchikey")$triclosan,
-               "XEFQLINVKFYRCS-UHFFFAOYSA-N")
+    expect_equal(cts_convert("triclosan", "chemical name", "inchikey")$triclosan,
+                 "XEFQLINVKFYRCS-UHFFFAOYSA-N")
 
-  expect_equal(cts_convert(NA, from = "Chemical Name", to = "inchikey"),
-               list(NA), ignore_attr = TRUE)
+    expect_equal(cts_convert(NA, from = "Chemical Name", to = "inchikey"),
+                 list(NA), ignore_attr = TRUE)
 
-  expect_equal(cts_convert(180, "pubchem cid", "inchikey")[[1]],
-               "CSCPPACGZOOCGX-UHFFFAOYSA-N")
-
-
+    expect_equal(cts_convert(180, "pubchem cid", "inchikey")[[1]],
+                 "CSCPPACGZOOCGX-UHFFFAOYSA-N")
+  })
 })
 
 test_that("fromto", {
-  skip_on_cran()
-  skip_if_not(up, "CTS service down")
-  to <- cts_to()
-  from <- cts_from()
+  # skip_on_cran()
+  # skip_if_not(up, "CTS service down")
+  vcr::use_cassette("cts_from-to", {
+    to <- cts_to()
+    from <- cts_from()
+  })
 
   expect_type(to, "character")
   expect_type(from, "character")


### PR DESCRIPTION
An alternative to #410.  Continues to use `vcr`, which is easier but doesn't work for all functions.


PR task list:
- [ ] Update NEWS
- [ ] Add tests (if appropriate)
- [ ] Update documentation with `devtools::document()`
- [ ] Check package passed