### PR TITLE
update actions/checkout

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/check-pkgdown.yml
+++ b/.github/workflows/check-pkgdown.yml
@@ -5,29 +5,29 @@ on:
     pull_request:
       branches:
         - master
-  
+
 name: check-pkgdown
-  
+
 jobs:
     check_pkgdown:
       runs-on: ubuntu-22.04
-      
+
       env:
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      
+
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - uses: r-lib/actions/setup-r@v2
           with:
             r-version: 'release'
         - uses: r-lib/actions/setup-r-dependencies@v2
           with:
             extra-packages: any::devtools, any::pkgdown
-          
+
         - name: Install dependencies
           run: devtools::install_github("https://github.com/ropensci-org/rotemplate")
           shell: Rscript {0}
-  
+
         - name: Check pkgdown
           run: pkgdown::check_pkgdown()
           shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
   test-coverage:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'


### PR DESCRIPTION
GitHub has started complaining about actions that use old versions of node, including actions/checkout v3, so this updates to v4