### PR TITLE
Download ChEMBL schema files once per session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 * `chembl_query()` now returns a named list with improved formatting for nested output.
 * Added new argument `output` to `chembl_query()` (values: "raw" or "tidy") to control output format. Raw format returns the full nested structure; tidy format attempts to flatten the results.
 * Added new `options` argument to `chembl_query()` for passing resource- and mode-specific options (cache file name, similarity threshold, database version, etc.).
-* `chembl_query()` can now replace NULL values with typed NA values (`NA_character_`, `NA_integer_`, `NA_real_`) based on the field schema when `replace_nulls = TRUE` in options.
+* `chembl_query()` can now replace NULL values with typed NA values (`NA_character_`, `NA_integer_`, `NA_real_`) based on the field schema when `replace_nulls = TRUE` in options. For this, the schema is retrieved from ChEMBL and cached for the session.
 
 ## BUG FIXES
 

--- a/R/chembl.R
+++ b/R/chembl.R
@@ -439,11 +439,16 @@ chembl_query_ws <- function(
   stem <- "https://www.ebi.ac.uk/chembl/api/data"
   opts <- list(...)
   if (replace_nulls) {
-    if (verbose) message("Retrieving schema to replace NULLs.")
-    # TODO retrieve once per session and cache
-    schema <- jsonlite::fromJSON(paste0(
-      "https://www.ebi.ac.uk/chembl/api/data/", resource, "/schema.json"
-    ))
+    if (exists(resource, envir = .chembl_schema_cache, inherits = FALSE)) {
+      if (verbose) message("Using cached schema.")
+      schema <- get(resource, envir = .chembl_schema_cache)
+    } else {
+      if (verbose) message("Retrieving schema to replace NULLs.")
+      schema <- jsonlite::fromJSON(paste0(
+        "https://www.ebi.ac.uk/chembl/api/data/", resource, "/schema.json"
+      ))
+      assign(resource, schema, envir = .chembl_schema_cache)
+    }
   } else {
     schema <- NULL
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,1 +1,3 @@
 if (getRversion() >= "2.15.1") utils::globalVariables(c("."))
+
+.chembl_schema_cache <- new.env(parent = emptyenv())


### PR DESCRIPTION
Related to #449.

There was an inconsistency issue between webservice requests and offline queries: when a value was missing from the respective database, the webservice often returned `NULL` but the offline query returned `NA` with the appropriate class (e.g. `NA_character_`). In PR #450 I implemented a fix in which we download a schema file from the ChEMBL resource and use that to replace `NULL` values with the appropriate `NA` values. However, downloading the schema with each query is inefficient.

This PR implements session level caching. When we load the package we create a new environment `chembl_schema_cache`. Whenever we need the schema file for a resource, we look for the schema in this environment. If we find it we use it, otherwise we download it and assign to the environment.

PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate)
- [x] Update documentation with `devtools::document()`
- [x] Check package passed