### PR TITLE
Skip online tests by default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,8 @@ We will try to be responsive and provide feedback.
 
 ## Testing
 
-You can test the package using `devtools::test()`. 
-Tests are disable in the `master` branch (commented out in `~tests\testthat.R`).
+You can test the package using `devtools::test()`. Remember to set the environment variable `RUN_ONLINE_TESTS` to "true" if you want to run tests that interact with online resources.
+Tests are disabled in the `master` branch (commented out in `~tests\testthat.R`).
 For local testing you can uncomment, or run `test_check("webchem")`.
 Please do not include changes to `~tests\testthat.R` in your PR.
 
@@ -33,6 +33,12 @@ Brief description of the PR
 PR task list:
 - [ ] Update NEWS
 - [ ] Add tests (if appropriate)
-- [ ] Knit README.Rmd to update test coverage badge (optional, requires ~40 GB of local databases; if skipped, a maintainer will knit and commit the updated README before merge)
 - [ ] Update documentation with `devtools::document()`
 - [ ] Check package passed
+
+Extra tasks (more for maintainers, but feel free to do them if you want):
+
+- [ ] Set the environment variable `RUN_ONLINE_TESTS` to "true"
+- [ ] Test package locally (requires ~40 GB of local databases)
+- [ ] Update README with `devtools::build_readme()` to update test coverage badge
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ Some consistency guidelines:
 
 16. If an API is no longer available defunct all the exported functions interacting with it.
 
+17. When adding tests, tests that interact with online resources should only run if the environment variable `RUN_ONLINE_TESTS` is set to "true".
+
 ### Data Sources
 
 You might think all webscraping is perfectly legal but it is unfortunately not that simple.

--- a/tests/testthat/test-bcpc.R
+++ b/tests/testthat/test-bcpc.R
@@ -1,7 +1,9 @@
-up <- ping_service("bcpc")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("bcpc"), TRUE)
+
 test_that("examples in the article are unchanged as far as it can be reasonably expected", {
   skip_on_cran()
   skip_if_not(up, "BCPC pesticide compendium is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   utils::data("lc50", package = "webchem")
   expect_warning(
@@ -24,6 +26,7 @@ test_that("examples in the article are unchanged as far as it can be reasonably 
 test_that("BCPC pesticide compendium, name", {
   skip_on_cran()
   skip_if_not(up, "BCPC pesticide compendium is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   comps <- c("Fluazinam", "S-Metolachlor", "balloon", NA, "Triclopyr-butotyl")
   o1 <- bcpc_query(comps, from = "name")
@@ -45,6 +48,7 @@ test_that("BCPC pesticide compendium, name", {
 test_that("BCPC pesticide compendium, invalid input", {
   skip_on_cran()
   skip_if_not(up, "BCPC pesticide compendium is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   comps <- c("balloon", NA)
   o1 <- bcpc_query(comps)
@@ -56,6 +60,7 @@ test_that("BCPC pesticide compendium, invalid input", {
 test_that("BCPC pesticide compendium, build_index", {
   skip_on_cran()
   skip_if_not(up, "BCPC pesticide compendium is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   idx <- suppressWarnings(webchem:::build_bcpc_idx(force_build = TRUE))
   expect_s3_class(idx, "data.frame")
@@ -68,6 +73,7 @@ test_that("BCPC pesticide compendium, build_index", {
 test_that("BCPC pesticide compendium, activity", {
   skip_on_cran()
   skip_if_not(up, "BCPC pesticide compendium is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   comps <- c("atrazine", "2,4-D", "Copper hydroxide", "ziram")
   o1 <- bcpc_query(comps)

--- a/tests/testthat/test-chebi.R
+++ b/tests/testthat/test-chebi.R
@@ -1,7 +1,9 @@
-up <- ping_service("chebi")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("chebi"), TRUE)
+
 test_that("examples in the article are unchanged", {
   skip_on_cran()
   skip_if_not(up, "CHEBI service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   utils::data("lc50", package = "webchem")
   cas_rns <- lc50[order(lc50$value)[1:3], "cas"]
@@ -28,6 +30,8 @@ test_that("examples in the article are unchanged", {
 test_that("chebi returns correct results", {
   skip_on_cran()
   skip_if_not(up, "CHEBI service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   a <- get_chebiid("Glyphosate", from = "all")
   b <- get_chebiid(c("triclosan", "glyphosate", "balloon", NA))
   A <- chebi_comp_entity("CHEBI:27744")
@@ -49,6 +53,7 @@ test_that("chebi returns correct results", {
 test_that("get_chebiid() handles special characters in SMILES",{
   skip_on_cran()
   skip_if_not(up, "CHEBI service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_equal(get_chebiid("C#C", from = "smiles", match = "first")$chebiid, "CHEBI:35328")
 })

--- a/tests/testthat/test-chembl.R
+++ b/tests/testthat/test-chembl.R
@@ -1,6 +1,10 @@
-up <- ping_service("chembl")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("chembl"), TRUE)
 
 test_that("chembl_dir_url()", {
+  skip_on_cran()
+  skip_if_not(up, "ChEMBL service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   # latest versions
   expect_equal(chembl_dir_url(), "https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_36")
   expect_equal(chembl_dir_url("latest"), "https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_36")
@@ -45,6 +49,7 @@ test_that("chembl_files()", {
 test_that("chembl_query() examples", {
   skip_on_cran()
   skip_if_not(up, "ChEMBL service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   #examples
   # Resource: "activity" - requires activity ID
@@ -157,6 +162,7 @@ test_that("chembl_query() examples", {
 test_that("More chembl_query()", {
   skip_on_cran()
   skip_if_not(up, "ChEMBL service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   #invalid inputs
   o5 <- chembl_query(c("CHEMBL1082", NA, "pumpkin", "CHEMBL25")) |>
@@ -216,6 +222,10 @@ test_that("More chembl_query()", {
 })
 
 test_that("chembl_atc_classes()", {
+  skip_on_cran()
+  skip_if_not(up, "ChEMBL service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   o1 <- chembl_atc_classes()
   o2 <- capture_messages(chembl_atc_classes(verbose = TRUE))
 
@@ -249,6 +259,7 @@ test_that("validate_chembl_version()", {
 test_that("chembl_status()", {
   skip_on_cran()
   skip_if_not(up, "ChEMBL service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   o1 <- chembl_status()
   o2 <- capture_messages(chembl_status(verbose = TRUE))
@@ -269,6 +280,10 @@ test_that("chembl_status()", {
 })
 
 test_that("force_schema() works everywhere", {
+  skip_on_cran()
+  skip_if_not(up, "ChEMBL service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   for (resource in chembl_resources()) {
     if (resource %in% c("image", "status")) next()
     resource |>

--- a/tests/testthat/test-chembl_offline.R
+++ b/tests/testthat/test-chembl_offline.R
@@ -2,10 +2,30 @@
 skip_on_cran()
 skip_on_ci()
 
-# Download ChEMBL database if not already downloaded
-db_download_chembl(version = "36", verbose = TRUE)
+version = "36"
+if (Sys.getenv("RUN_ONLINE_TESTS") == "true") {
+  # Download ChEMBL database if not already downloaded
+  db_download_chembl(version = version, verbose = TRUE)
+}
+
+db_exists <- function(version) {
+  version <- validate_chembl_version(version)
+  tryCatch(
+    {
+      con <- connect_chembl(version = version)
+      on.exit(DBI::dbDisconnect(con))
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+}
 
 test_that("chembl_offline_chembl_id_lookup works", {
+  skip_if_not(
+    db_exists(version = version),
+    message = "Offline database not available"
+  )
+
   a <- chembl_query_offline(
     query = "CHEMBL1",
     resource = "chembl_id_lookup",
@@ -26,6 +46,11 @@ test_that("chembl_offline_chembl_id_lookup works", {
 })
 
 test_that("informative error when query and resource do not match", {
+  skip_if_not(
+    db_exists(version = version),
+    message = "Offline database not available"
+  )
+
   msg <- tryCatch(
     chembl_query_offline(
       query = c("CHEMBL1082", "CHEMBL3988026") , resource = "molecule"),
@@ -35,6 +60,11 @@ test_that("informative error when query and resource do not match", {
 })
 
 test_that("fully implemented resources work", {
+  skip_if_not(
+    db_exists(version = version),
+    message = "Offline database not available"
+  )
+
   full <- c(
     "activity",
     "atc_class",
@@ -63,6 +93,11 @@ test_that("fully implemented resources work", {
 })
 
 test_that("partially implemented resources work", {
+  skip_if_not(
+    db_exists(version = version),
+    message = "Offline database not available"
+  )
+
   partial = c(
     "document",
     "drug",

--- a/tests/testthat/test-chembl_offline.R
+++ b/tests/testthat/test-chembl_offline.R
@@ -60,10 +60,7 @@ test_that("informative error when query and resource do not match", {
 })
 
 test_that("fully implemented resources work", {
-  skip_if_not(
-    db_exists(version = version),
-    message = "Offline database not available"
-  )
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   full <- c(
     "activity",
@@ -93,10 +90,7 @@ test_that("fully implemented resources work", {
 })
 
 test_that("partially implemented resources work", {
-  skip_if_not(
-    db_exists(version = version),
-    message = "Offline database not available"
-  )
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   partial = c(
     "document",

--- a/tests/testthat/test-cir.R
+++ b/tests/testthat/test-cir.R
@@ -1,7 +1,9 @@
-up <- ping_service("cir")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("cir"), TRUE)
+
 test_that("cir_query()", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_equal(cir_query('Triclosan', 'mw')$mw[1], 289.5451)
   expect_equal(cir_query('xxxxxxx', 'mw')$mw[1], NA)
@@ -19,6 +21,7 @@ test_that("cir_query()", {
 test_that("cir_query() doesn't mistake NA for sodium", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_true(is.na(cir_query(as.character(NA), 'cas')$cas))
 })
@@ -34,6 +37,7 @@ test_that("cir_query() handles special characters in SMILES", {
 test_that("cir_query() handles NA queries and queries that return NA", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_identical(
     cir_query(c("Triclosan", "pumpkin", NA), representation = "cas",match = "first"),
@@ -45,6 +49,7 @@ test_that("cir_query() handles NA queries and queries that return NA", {
 test_that("cir_img()", {
   skip_on_cran()
   skip_if_not(up, "CIR server is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_true(is.null(cir_img('CCO', tempdir())))
   fl <- file.path(tempdir(), 'CCO.png')

--- a/tests/testthat/test-cts.R
+++ b/tests/testthat/test-cts.R
@@ -1,8 +1,9 @@
-up <- ping_service("cts")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("cts"), TRUE)
+
 test_that("cts_compinfo()", {
   skip_on_cran()
-
   skip_if_not(up, "CTS service down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_true(is.na(cts_compinfo("xxx")))
 
@@ -21,6 +22,7 @@ test_that("cts_compinfo()", {
 test_that("cts_convert()", {
   skip_on_cran()
   skip_if_not(up, "CTS service down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   comp <- c('Triclosan', 'Hexane')
   expect_error(cts_convert(comp, c('Chemical Name', 'CAS'), 'CAS'))
@@ -48,6 +50,8 @@ test_that("cts_convert()", {
 test_that("fromto", {
   skip_on_cran()
   skip_if_not(up, "CTS service down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   to <- cts_to()
   from <- cts_from()
 

--- a/tests/testthat/test-extractors.R
+++ b/tests/testthat/test-extractors.R
@@ -10,8 +10,10 @@
 # })
 
 test_that("extractors work with opsin", {
+  up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("opsin"), TRUE)
   skip_on_cran()
-  skip_if_not(ping_service("opsin"), "OPSIN service is down")
+  skip_if_not(up, "OPSIN service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   out_opsin_query <- opsin_query(c('Cyclopropane', 'Octane'))
   expect_error(cas(out_opsin_query), "CAS is not returned by this datasource!")
@@ -23,8 +25,10 @@ test_that("extractors work with opsin", {
 })
 
 test_that("extractors work with BCPC compendium", {
+  up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("bcpc"), TRUE)
   skip_on_cran()
-  skip_if_not(ping_service("bcpc"), "BCPC compendium not reachable")
+  skip_if_not(up, "BCPC compendium not reachable")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   out_bcpc_query <- bcpc_query(c('Fluazinam', 'Diclofop'), from = 'name')
   expect_equal(cas(out_bcpc_query), c("79622-59-6", "40843-25-2"),
@@ -37,8 +41,10 @@ test_that("extractors work with BCPC compendium", {
 })
 
 test_that("extractors work with Wikidata", {
+  up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("wd"), TRUE)
   skip_on_cran()
-  skip_if_not(ping_service("wd"), "Wikidata service is down")
+  skip_if_not(up, "Wikidata service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   id <- c("Q408646", "Q18216")
   out_wd_ident <- wd_ident(id)
@@ -52,8 +58,10 @@ test_that("extractors work with Wikidata", {
 })
 
 test_that("extractors work with pubchem", {
+  up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("pc"), TRUE)
   skip_on_cran()
-  skip_if_not(ping_service("pc"), "Pubchem service is down")
+  skip_if_not(up, "Pubchem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   out_pc_prop <- pc_prop(c(5564, 2244))
   out_pc_prop2 <- pc_prop(5564, properties = c('MolecularFormula',

--- a/tests/testthat/test-flavornet.R
+++ b/tests/testthat/test-flavornet.R
@@ -1,7 +1,9 @@
-up <- ping_service("fn")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("fn"), TRUE)
+
 test_that("fn_percept()", {
   skip_on_cran()
   skip_if_not(up, "Flavornet is unreachable")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   a <- fn_percept("123-32-0")
   b <- fn_percept(c("75-07-0", "123-32-0"))

--- a/tests/testthat/test-foodb.R
+++ b/tests/testthat/test-foodb.R
@@ -2,10 +2,28 @@
 skip_on_cran()
 skip_on_ci()
 
-# Download database if not already downloaded
-db_download_foodb(verbose = TRUE)
+if (Sys.getenv("RUN_ONLINE_TESTS") == "true") {
+  # Download database if not already downloaded
+  db_download_foodb(verbose = TRUE)
+}
+
+db_exists <- function() {
+  tryCatch(
+    {
+      con <- connect_foodb()
+      on.exit(DBI::dbDisconnect(con))
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+}
 
 test_that("database ids are unique", {
+  skip_if_not(
+    db_exists(),
+    message = "Offline database not available"
+  )
+
   con <- connect_foodb()
   compounds <- dplyr::tbl(con, "Compound") |>
     dplyr::select(c(
@@ -23,6 +41,11 @@ test_that("database ids are unique", {
 })
 
 test_that("foodb_list_compounds() works", {
+  skip_if_not(
+    db_exists(),
+    message = "Offline database not available"
+  )
+
   harmonised <- foodb_list_compounds(idtype = "name", include_synonyms = FALSE)
   syns <- foodb_list_compounds(idtype = "name", include_synonyms = TRUE)
 
@@ -32,6 +55,11 @@ test_that("foodb_list_compounds() works", {
 })
 
 test_that("foodb_convert() works", {
+  skip_if_not(
+    db_exists(),
+    message = "Offline database not available"
+  )
+
   # Single query
   qA <- foodb_convert("4", from = "id", to = "public_id")
   qB <- foodb_convert("FDB000004", from = "public_id", to = "name")
@@ -62,6 +90,11 @@ test_that("foodb_convert() works", {
 })
 
 test_that("foodb_query() works", {
+  skip_if_not(
+    db_exists(),
+    message = "Offline database not available"
+  )
+
   # single query
   qA <- foodb_query("Biotin")$Biotin
   qB <- foodb_query("3,7-Dimethylquercetin")$`3,7-Dimethylquerceti`

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -1,14 +1,15 @@
 # These all might occasionally fail because cts_translate() is currently
 # somewhat unreliable.
 
-etox_up <- ping_service("etox")
-fn_up <- ping_service("fn")
-up <- ping_service("cts")
+etox_up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("etox"), TRUE)
+fn_up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("fn"), TRUE)
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("cts"), TRUE)
 
 test_that("with_cts() works when no translation needed", {
   skip_on_cran()
   skip_if_not(etox_up, "ETOX down!")
   skip_if_not(up, "CTS service down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   CASs <- c("75-07-0",  "64-17-5")
   a <-
@@ -27,6 +28,7 @@ test_that("with_cts() translates", {
   skip_on_cran()
   skip_if_not(etox_up, "ETOX down!")
   skip_if_not(up, "CTS service down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   x <-
     with_cts(query = "XDDAORKBJWWYJS-UHFFFAOYSA-N", from = "inchikey", .f = "get_etoxid")
@@ -43,6 +45,7 @@ test_that("find_db() function works", {
   skip_if_not(fn_up)
   skip_if_not(etox_up)
   skip_if_not(up, "CTS service down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   out <- find_db(c("triclosan", NA, "balloon"),
                         from = "name",

--- a/tests/testthat/test-nist.R
+++ b/tests/testthat/test-nist.R
@@ -1,9 +1,11 @@
-
 library(robotstxt)
-up <- ping_service("nist")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("nist"), TRUE)
+
 test_that("NIST webbook is still OK with being scraped", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   expect_true(
     paths_allowed("https://webbook.nist.gov/cgi/cbook.cgi",
                   user_agent = 'webchem (https://github.com/ropensci/webchem)')
@@ -13,6 +15,7 @@ test_that("NIST webbook is still OK with being scraped", {
 test_that("nist_ri() works when only one row of data", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   testdf <- nist_ri("78-70-6", from = "cas",
                     type = "alkane",
@@ -35,6 +38,7 @@ test_that("nist_ri() works when only one row of data", {
 test_that("nist_ri() works with inchikey query", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   testdf <- nist_ri(
     "UHEPJGULSIKKTP-UHFFFAOYSA-N",
@@ -50,6 +54,7 @@ test_that("nist_ri() works with inchikey query", {
 test_that("nist_ri() works with inchi query", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   testdf <- nist_ri(
     "1S/C8H14O/c1-7(2)5-4-6-8(3)9/h5H,4,6H2,1-3H3",
@@ -65,6 +70,7 @@ test_that("nist_ri() works with inchi query", {
 test_that("nist_ri() works with name query", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   testdf <- nist_ri(
     "myrcene",
@@ -80,6 +86,7 @@ test_that("nist_ri() works with name query", {
 test_that("nist_ri() works with multiple queries", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   myRIs <-
     nist_ri(
@@ -96,6 +103,7 @@ test_that("nist_ri() works with multiple queries", {
 test_that("nist_ri() can return multiple types", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   out <- nist_ri("78-70-6", type = c("kovats","linear"), polarity="non-polar",
                  temp_prog = "custom")
@@ -110,6 +118,7 @@ test_that("nist_ri() can return multiple types", {
 test_that("cas =  is deprecated gently", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_warning(
     nist_ri(cas = "78-70-6"),
@@ -121,6 +130,7 @@ test_that("cas =  is deprecated gently", {
 test_that("nist_ri works with NAs", {
   skip_on_cran()
   skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   test <- nist_ri("107-86-8",
                   from = "cas",
@@ -140,6 +150,10 @@ test_that("nist_ri works with NAs", {
 })
 
 test_that("a name returns CAS", {
+  skip_on_cran()
+  skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   test1 <- nist_ri("α-methyl-Benzenepropanamine", from = "name", type="kovats")
   expect_equal(test1[[1,"cas"]], "22374-89-6")
   test2 <- nist_ri("α-methyl-Benzenepropanamine", from = "name", type="lee")
@@ -148,12 +162,20 @@ test_that("a name returns CAS", {
 })
 
 test_that("a record with no CAS number returns expected output", {
+  skip_on_cran()
+  skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   test <- nist_ri("(Z,Z)-alpha-Farnesene", from="name", type = "linear", polarity="polar")
   expect_equal(test$query, "(Z,Z)-α-Farnesene")
   expect_equal(test$cas, NA)
 })
 
 test_that("a query with spaces returns the expected output", {
+  skip_on_cran()
+  skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   test <- nist_ri(query = "methyl glyoxal", from="name",temp_prog = "ramp")
   expect_equal(test$query, "methyl glyoxal")
   expect_equal(test$cas, "78-98-8")
@@ -161,6 +183,10 @@ test_that("a query with spaces returns the expected output", {
 })
 
 test_that("nist_ri() can deal appropriately with a mixture of queries", {
+  skip_on_cran()
+  skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   test <- nist_ri(query=c(NA, "baloon", "methane", "deuterium", "hexanol"), from = "name",
                   type=c("kovats","linear"), polarity="polar",
                   temp_prog = "ramp")
@@ -183,6 +209,10 @@ test_that("nist_ri() can deal appropriately with a mixture of queries", {
 })
 
 test_that("nist_ri() works with multiple temperature program arguments",{
+  skip_on_cran()
+  skip_if_not(up, "NIST Web Book is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   df_ramp <- nist_ri("78-70-6", from = "cas", type = c("kovats"), polarity="polar",
                         temp_prog = "ramp")
   df_iso <- nist_ri("78-70-6", type = c("kovats"), polarity="polar",

--- a/tests/testthat/test-opsin.R
+++ b/tests/testthat/test-opsin.R
@@ -1,7 +1,9 @@
-up <- ping_service("opsin")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("opsin"), TRUE)
+
 test_that("opsin_query()", {
   skip_on_cran()
   skip_if_not(up, "OPSIN service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   o1 <- opsin_query(c('Cyclopropane', 'Octane'))
   o2 <- suppressWarnings(opsin_query(c('xxxx')))

--- a/tests/testthat/test-pubchem.R
+++ b/tests/testthat/test-pubchem.R
@@ -1,7 +1,10 @@
-up <- ping_service("pc")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("pc"), TRUE)
+
 test_that("examples in the article are unchanged", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   #values come from test-etox
   cas <- c("105-67-9", "1570-64-5", NA, "1912-24-9", "71-43-2", "6190-65-4")
   cids <- get_cid(cas, from = "xref/rn", match = "first")
@@ -20,6 +23,7 @@ test_that("examples in the article are unchanged", {
 test_that("get_cid()", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   #from name
   expect_true("5564" %in% get_cid("Triclosan")$cid)
@@ -93,6 +97,7 @@ test_that("get_cid()", {
 test_that("get_cid() handles special characters in SMILES", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_equal(get_cid("C#C", from = "smiles")$cid, "6326")
 })
@@ -100,6 +105,7 @@ test_that("get_cid() handles special characters in SMILES", {
 test_that("pc_prop", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   b <- suppressWarnings(pc_prop("xxx", properties = "SMILES"))
   c <- pc_prop("5564", properties = c("SMILES", "InChIKey"))
@@ -132,6 +138,8 @@ test_that("pc_prop", {
 test_that("pc_synonyms", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   expect_equal(pc_synonyms(NA), list(NA), ignore_attr = TRUE)
   expect_equal(pc_synonyms("Acetyl Salicylic Acid")[[1]][1], "aspirin")
   expect_equal(length(pc_synonyms(c("Triclosan", "Aspirin"))), 2)
@@ -143,6 +151,7 @@ test_that("pc_synonyms", {
 test_that("cid integration tests", {
   skip_on_cran()
   skip_if_not(ping_pubchem(), "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   expect_equal(pc_prop(get_cid("Triclosan")$cid[1],
                        properties = "SMILES")$SMILES,
@@ -154,6 +163,7 @@ test_that("cid integration tests", {
 test_that("pc_page()", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   a <- pc_page(c(311, 176, 1118, "balloon", NA), "Dissociation Constants")
 
@@ -168,6 +178,7 @@ test_that("pc_page()", {
 test_that("pc_sect()", {
   skip_on_cran()
   skip_if_not(up, "PubChem service is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   a <- pc_sect(c(311, 176, 1118, "balloon", NA), "Dissociation Constants")
   expect_s3_class(a, c("tbl_df", "tbl", "data.frame"))
@@ -175,6 +186,7 @@ test_that("pc_sect()", {
   expect_equal(mean(c("2.79", "4.76 (at 25 °C)", NA) %in% a$Result), 1)
   expect_equal(mean(c("DrugBank", NA) %in% a$SourceName), 1)
   expect_equal(mean(c("DB04272", "DB03166", NA) %in% a$SourceID), 1)
+
   b <- pc_sect(2231, "depositor-supplied synonyms", "substance")
   expect_s3_class(b, c("tbl_df", "tbl", "data.frame"))
   expect_equal(names(b), c("SID", "Name", "Result", "SourceName", "SourceID"))

--- a/tests/testthat/test-srs.R
+++ b/tests/testthat/test-srs.R
@@ -1,8 +1,9 @@
-up <- ping_service("srs")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("srs"), TRUE)
 
 test_that("SRS returns correct results", {
   skip_on_cran()
   skip_if_not(up, "SRS is down")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   a <- srs_query(NA)
   b <- srs_query("balloon")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,4 +1,5 @@
-up <- ping_service("cs_web")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("cs_web"), TRUE)
+
 test_that("examples in the article are unchanged", {
   expect_false(is.inchikey("BQJCRHHNABKAKU-KBQPJGBKS-AN"))
   # The default value for verbose has changed and it now requires verbose = TRUE
@@ -26,6 +27,10 @@ test_that("assert()", {
 })
 
 test_that("db_files()", {
+  skip_on_cran()
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
+
   o1 <- db_files("chembl", version = "35")
   expect_true(all(o1$url_exists))
   expect_error(db_files("hello"))
@@ -62,6 +67,7 @@ test_that("is.inchikey() returns correct results", {
   skip_on_cran()
   skip_on_ci()
   skip_if_not(up, "ChemSpider service is down, skipping tests")
+  skip_if_not(Sys.getenv("RUN_ONLINE_TESTS") == "true", "Skipping online tests")
 
   vcr::use_cassette("is_inchikey_cs_2", {
     g <- is.inchikey('BQJCRHHNABKAKU-KBQPJGBKSA-N', type = 'chemspider')

--- a/tests/testthat/test-wikidata.R
+++ b/tests/testthat/test-wikidata.R
@@ -1,7 +1,10 @@
-up <- ping_service("wd")
+up <- ifelse(Sys.getenv("RUN_ONLINE_TESTS") == "true", ping_service("wd"), TRUE)
+
 test_that("get_wdid returns correct results", {
   skip_on_cran()
   skip_if_not(up, "Wikidata service is down")
+
+
   # test general
   comps <- c('DDT', 'Aspirin', 'xdewrwdcadsr4w', 'acetic acid')
   o1 <- get_wdid(comps, match = 'best')


### PR DESCRIPTION
Related to issue #461, #464.

This PR introduces a new environment variable called `RUN_ONLINE_TESTS`. Tests that require an internet connection (webservice requests, database downloads, webservice vs offline database comparisons) will only run if this variable is set to "true". However, if a database has already been downloaded, tests that require the offline database but do not require webservice access will run regardless of `RUN_ONLINE_TESTS` (since these are no longer "online" tests).

PR task list:
- [x] (Not relevant) Update NEWS
- [x] Add tests (if appropriate)
- [x] (Not relevant) Knit README.Rmd to update test coverage badge (optional, requires ~40 GB of local databases; if skipped, a maintainer will knit and commit the updated README before merge)
- [x] (not relevant) Update documentation with `devtools::document()`
- [x] Check package passed