### PR TITLE
add action with `RUN_ONLINE_TESTS: true`

### DIFF
--- a/.github/workflows/R-CMD-check-online-tests.yaml
+++ b/.github/workflows/R-CMD-check-online-tests.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 3 1 * *'
   workflow_dispatch:
 
-name: R-CMD-check
+name: R-CMD-check online
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/R-CMD-check-online-tests.yaml
+++ b/.github/workflows/R-CMD-check-online-tests.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from
+# https://github.com/r-lib/actions/blob/v2-branch/examples/check-standard.yaml
+
+on:
+  schedule:
+    - cron: '0 3 1 * *'
+  workflow_dispatch:
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      RUN_ONLINE_TESTS: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/check-online-tests.yaml
+++ b/.github/workflows/check-online-tests.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 3 1 * *'
   workflow_dispatch:
 
-name: R-CMD-check online
+name: R-CMD-check with online test
 
 jobs:
   R-CMD-check:


### PR DESCRIPTION
This adds a GitHub action that runs on the 1st of the month at 3:00am or when you click a button (see screenshot below) that has `RUN_ONLINE_TESTS` set to `"true"` so as to not skip tests that hit APIs. The idea is that once a month (or whenever you want), you get a notification if any tests fail, then you can investigate manually.  You can also run this manually on any PR branch.  It still runs on all platforms in case there are platform-specific problems with the R code of these functions.

<img width="327" height="186" alt="Screenshot 2026-07-28 at 10 36 05 AM" src="https://github.com/user-attachments/assets/bdd23b76-3296-4008-bf7d-19525545bc19" />
